### PR TITLE
Show a helpful error message if deploy/setup is run and no tasks are configured

### DIFF
--- a/lib/tomo/runtime.rb
+++ b/lib/tomo/runtime.rb
@@ -10,6 +10,7 @@ module Tomo
     autoload :ExecutionPlan, "tomo/runtime/execution_plan"
     autoload :HostExecutionStep, "tomo/runtime/host_execution_step"
     autoload :InlineThreadPool, "tomo/runtime/inline_thread_pool"
+    autoload :NoTasksError, "tomo/runtime/no_tasks_error"
     autoload :PrivilegedTask, "tomo/runtime/privileged_task"
     autoload :SettingsInterpolation, "tomo/runtime/settings_interpolation"
     autoload :SettingsRequiredError, "tomo/runtime/settings_required_error"
@@ -32,10 +33,14 @@ module Tomo
     end
 
     def deploy!
+      NoTasksError.raise_with(task_type: "deploy") if deploy_tasks.empty?
+
       execution_plan_for(deploy_tasks, release: :new).execute
     end
 
     def setup!
+      NoTasksError.raise_with(task_type: "setup") if setup_tasks.empty?
+
       execution_plan_for(setup_tasks, release: :tmp).execute
     end
 
@@ -45,6 +50,8 @@ module Tomo
     end
 
     def execution_plan_for(tasks, release: :current, args: [])
+      raise ArgumentError, "tasks cannot be empty" if tasks.empty?
+
       ExecutionPlan.new(
         tasks: tasks,
         hosts: hosts,

--- a/lib/tomo/runtime/no_tasks_error.rb
+++ b/lib/tomo/runtime/no_tasks_error.rb
@@ -1,0 +1,18 @@
+module Tomo
+  class Runtime
+    class NoTasksError < Error
+      attr_accessor :task_type
+
+      def to_console
+        <<~ERROR
+          No #{task_type} tasks are configured.
+          You can specify them using a #{yellow(task_type)} block in #{yellow(Tomo::DEFAULT_CONFIG_PATH)}.
+
+          More configuration documentation and examples can be found here:
+
+            #{blue('https://tomo-deploy.com/configuration')}
+        ERROR
+      end
+    end
+  end
+end

--- a/test/tomo/runtime_test.rb
+++ b/test/tomo/runtime_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class Tomo::RuntimeTest < Minitest::Test
+  def test_deploy_raises_if_no_deploy_tasks
+    runtime = Tomo::Configuration.new.build_runtime
+    assert_raises(Tomo::Runtime::NoTasksError) do
+      runtime.deploy!
+    end
+  end
+
+  def test_setup_raises_if_no_setup_tasks
+    runtime = Tomo::Configuration.new.build_runtime
+    assert_raises(Tomo::Runtime::NoTasksError) do
+      runtime.setup!
+    end
+  end
+
+  def test_execution_plan_for_raises_if_tasks_is_empty
+    runtime = Tomo::Configuration.new.build_runtime
+    assert_raises(ArgumentError) do
+      runtime.execution_plan_for([])
+    end
+  end
+end


### PR DESCRIPTION
If `.tomo/config.rb` is lacking a list of deploy or setup tasks and the user tries to run `tomo deploy` or `tomo setup`, display a useful message instead of "Deployed tomo to no hosts".