### PR TITLE
Increase build parallelism in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,25 +103,15 @@ workflows:
                 - master
       - rubocop
       - test_unit
-      - test_docker:
-          requires:
-            - rubocop
-            - test_unit
-      - test_e2e:
-          requires:
-            - test_docker
+      - test_docker
+      - test_e2e
   cron-workflow:
     jobs:
       - mkdocs_build
       - rubocop
       - test_unit
-      - test_docker:
-          requires:
-            - rubocop
-            - test_unit
-      - test_e2e:
-          requires:
-            - test_docker
+      - test_docker
+      - test_e2e
     triggers:
       - schedule:
           cron: "0 13 * * 6"


### PR DESCRIPTION
Open source projects get 4 free containers, so we can run more jobs at once to shorten overall build time.