### PR TITLE
Fix a bug where bash completions were not working for deploy/run/setup options

### DIFF
--- a/lib/tomo/runtime.rb
+++ b/lib/tomo/runtime.rb
@@ -50,8 +50,6 @@ module Tomo
     end
 
     def execution_plan_for(tasks, release: :current, args: [])
-      raise ArgumentError, "tasks cannot be empty" if tasks.empty?
-
       ExecutionPlan.new(
         tasks: tasks,
         hosts: hosts,

--- a/lib/tomo/testing/docker_image.rb
+++ b/lib/tomo/testing/docker_image.rb
@@ -86,7 +86,10 @@ module Tomo
         else
           args.prepend("--publish-all ")
         end
-        Local.capture("docker run #{args}")[/\S+/]
+        Local.capture("docker run #{args}")[/\S+/].tap do
+          # Allow some time for the container to finish booting
+          sleep 0.1
+        end
       end
 
       def find_ssh_port

--- a/test/tomo/cli/completions_test.rb
+++ b/test/tomo/cli/completions_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+require "fileutils"
+require "open3"
+require "securerandom"
+require "tmpdir"
+
+class Tomo::CLI::CompletionsTest < Minitest::Test
+  def test_completions_include_setting_names
+    output = in_temp_dir do
+      capture! "bundle exec tomo init"
+      capture! "bundle exec tomo --complete deploy -s"
+    end
+
+    assert_match(/^git_branch=$/, output)
+    assert_match(/^git_url=$/, output)
+  end
+
+  private
+
+  def in_temp_dir(&block)
+    dir = File.join(Dir.tmpdir, "tomo_test_#{SecureRandom.hex(8)}")
+    FileUtils.mkdir_p(dir)
+    Dir.chdir(dir, &block)
+  end
+
+  def capture!(command)
+    Bundler.with_original_env do
+      gemfile = File.expand_path("../../../Gemfile", __dir__)
+      output, status = Open3.capture2({ "BUNDLE_GEMFILE" => gemfile }, command)
+      raise "Command failed: #{command}" unless status.success?
+
+      output
+    end
+  end
+end

--- a/test/tomo/cli/completions_test.rb
+++ b/test/tomo/cli/completions_test.rb
@@ -1,14 +1,10 @@
 require "test_helper"
-require "fileutils"
-require "open3"
-require "securerandom"
-require "tmpdir"
 
 class Tomo::CLI::CompletionsTest < Minitest::Test
   def test_completions_include_setting_names
-    output = in_temp_dir do
-      capture! "bundle exec tomo init"
-      capture! "bundle exec tomo --complete deploy -s"
+    output = Tomo::Testing::Local.in_temp_dir do
+      capture "bundle exec tomo init"
+      capture "bundle exec tomo --complete deploy -s"
     end
 
     assert_match(/^git_branch=$/, output)
@@ -17,19 +13,9 @@ class Tomo::CLI::CompletionsTest < Minitest::Test
 
   private
 
-  def in_temp_dir(&block)
-    dir = File.join(Dir.tmpdir, "tomo_test_#{SecureRandom.hex(8)}")
-    FileUtils.mkdir_p(dir)
-    Dir.chdir(dir, &block)
-  end
-
-  def capture!(command)
-    Bundler.with_original_env do
-      gemfile = File.expand_path("../../../Gemfile", __dir__)
-      output, status = Open3.capture2({ "BUNDLE_GEMFILE" => gemfile }, command)
-      raise "Command failed: #{command}" unless status.success?
-
-      output
+  def capture(command)
+    Tomo::Testing::Local.with_tomo_gemfile do
+      Tomo::Testing::Local.capture(command)
     end
   end
 end

--- a/test/tomo/runtime_test.rb
+++ b/test/tomo/runtime_test.rb
@@ -14,11 +14,4 @@ class Tomo::RuntimeTest < Minitest::Test
       runtime.setup!
     end
   end
-
-  def test_execution_plan_for_raises_if_tasks_is_empty
-    runtime = Tomo::Configuration.new.build_runtime
-    assert_raises(ArgumentError) do
-      runtime.execution_plan_for([])
-    end
-  end
 end


### PR DESCRIPTION
In order to determine completions, `DeployOptions` creates a hypothetical (empty) execution plan in order to compute the full list of settings. A recent change added an assertion that prevents empty execution plans, thus breaking the completions.

Fix by restoring the ability to create empty execution plans.

Also: In some cases when testing locally the test can attempt to open a connection to the docker container before the sshd process in the container is ready. Work around this by adding a slight delay after the starting the docker container.