### PR TITLE
Refactor `SSH.connect` options for easier standalone use

### DIFF
--- a/lib/tomo/plugin/core.rb
+++ b/lib/tomo/plugin/core.rb
@@ -8,24 +8,20 @@ module Tomo::Plugin
     helpers Tomo::Plugin::Core::Helpers
     tasks Tomo::Plugin::Core::Tasks
 
-    defaults application:                  "default",
-             concurrency:                  10,
-             current_path:                 "%<deploy_to>/current",
-             deploy_to:                    "/var/www/%<application>",
-             keep_releases:                10,
-             linked_dirs:                  [],
-             linked_files:                 [],
-             release_json_path:            "%<release_path>/.tomo_release.json",
-             releases_path:                "%<deploy_to>/releases",
-             revision_log_path:            "%<deploy_to>/revisions.log",
-             shared_path:                  "%<deploy_to>/shared",
-             tmp_path:                     "/tmp/tomo",
-             run_args:                     [],
-             ssh_connect_timeout:          5,
-             ssh_executable:               "ssh",
-             ssh_extra_opts:               %w[-o PasswordAuthentication=no],
-             ssh_forward_agent:            true,
-             ssh_reuse_connections:        true,
-             ssh_strict_host_key_checking: "accept-new"
+    defaults Tomo::SSH::Options::DEFAULTS.merge(
+      application:       "default",
+      concurrency:       10,
+      current_path:      "%<deploy_to>/current",
+      deploy_to:         "/var/www/%<application>",
+      keep_releases:     10,
+      linked_dirs:       [],
+      linked_files:      [],
+      release_json_path: "%<release_path>/.tomo_release.json",
+      releases_path:     "%<deploy_to>/releases",
+      revision_log_path: "%<deploy_to>/revisions.log",
+      shared_path:       "%<deploy_to>/shared",
+      tmp_path:          "/tmp/tomo",
+      run_args:          []
+    )
   end
 end

--- a/lib/tomo/runtime/task_runner.rb
+++ b/lib/tomo/runtime/task_runner.rb
@@ -36,7 +36,7 @@ module Tomo
 
       def connect(host)
         Current.with(host: host) do
-          conn = SSH.connect(host: host, options: SSH::Options.new(settings))
+          conn = SSH.connect(host: host, options: ssh_options)
           remote = Remote.new(conn, context, helper_modules)
           return remote unless block_given?
 
@@ -51,6 +51,11 @@ module Tomo
       private
 
       attr_reader :helper_modules, :tasks_by_name
+
+      def ssh_options
+        # TODO: replace with Hash#slice after dropping Ruby 2.4 support
+        settings.select { |key| SSH::Options::DEFAULTS.key?(key) }
+      end
     end
   end
 end

--- a/lib/tomo/ssh.rb
+++ b/lib/tomo/ssh.rb
@@ -13,7 +13,9 @@ module Tomo
     autoload :UnsupportedVersionError, "tomo/ssh/unsupported_version_error"
 
     class << self
-      def connect(host:, options:)
+      def connect(host:, options: {})
+        options = Options.new(options) unless options.is_a?(Options)
+
         Tomo.logger.connect(host)
         return Connection.dry_run(host, options) if Tomo.dry_run?
 

--- a/lib/tomo/ssh/options.rb
+++ b/lib/tomo/ssh/options.rb
@@ -1,17 +1,22 @@
 module Tomo
   module SSH
     class Options
+      DEFAULTS = {
+        ssh_connect_timeout: 5,
+        ssh_executable: "ssh".freeze,
+        ssh_extra_opts: %w[-o PasswordAuthentication=no].map(&:freeze),
+        ssh_forward_agent: true,
+        ssh_reuse_connections: true,
+        ssh_strict_host_key_checking: "accept-new".freeze
+      }.freeze
+
       attr_reader :executable
 
-      def initialize(settings)
-        @executable = settings.fetch(:ssh_executable)
-        @extra_opts = settings.fetch(:ssh_extra_opts)
-        @forward_agent = settings.fetch(:ssh_forward_agent)
-        @reuse_connections = settings.fetch(:ssh_reuse_connections)
-        @connect_timeout = settings.fetch(:ssh_connect_timeout)
-        @strict_host_key_checking = settings.fetch(
-          :ssh_strict_host_key_checking
-        )
+      def initialize(options)
+        DEFAULTS.merge(options).each do |attr, value|
+          unprefixed_attr = attr.to_s.sub(/^ssh_/, "")
+          send(:"#{unprefixed_attr}=", value)
+        end
         freeze
       end
 
@@ -33,8 +38,9 @@ module Tomo
 
       private
 
-      attr_reader :connect_timeout, :extra_opts, :forward_agent,
-                  :reuse_connections, :strict_host_key_checking
+      attr_writer :executable
+      attr_accessor :connect_timeout, :extra_opts, :forward_agent,
+                    :reuse_connections, :strict_host_key_checking
 
       def control_opts(path, verbose)
         opts = [


### PR DESCRIPTION
Before, you needed to pass an `SSH::Options` object into `SSH.connect`, and constructing `SSH::Options` required supplying a bunch of required values that had no defaults. That meant using `SSH.connect` outside of tomo's settings system was difficult.

With this commit the SSH API has been refactored such that `SSH.connect` now accepts a simple hash of options, not an opaque object, and there are reasonable default options such that this hash is completely optional. In the future, if tomo were to officially support a standalone SSH use case (sort of like SSHKit), this refactor makes the API much more approachable.