### PR TITLE
Introduce `tomo TASK` as a CLI shorthand for `tomo run TASK`

### DIFF
--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -20,6 +20,12 @@ This will run the [rails:console](../plugins/rails.md#railsconsole) task on the 
 $ tomo run core:clean_releases
 ```
 
+When you specify a task name, the `run` command is implied and can be omitted, so this works as well:
+
+```plain
+$ tomo core:clean_releases
+```
+
 You can run any task defined by plugins loaded by the [plugin](../configuration.md#pluginname_or_relative_path) declarations in `.tomo/config.rb`. To see a list of available tasks, run the [tasks](tasks.md) command.
 
 During the `run` command, tomo will initialize the `:release_path` setting to be equal to the current symlink (i.e. `/var/www/my-app/current`). This means that the task will run within the current release.

--- a/lib/tomo/cli.rb
+++ b/lib/tomo/cli.rb
@@ -51,13 +51,20 @@ module Tomo
       argv << "" if argv.shift == "--complete"
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def lookup_command(argv)
       command_name = argv.first unless Completions.active? && argv.length == 1
       command_name = Abbrev.abbrev(COMMANDS.keys)[command_name]
       argv.shift if command_name
 
+      # command_name = "run" if command_name.nil? && task_format?(argv.first)
       command = COMMANDS[command_name] || Tomo::Commands::Default
       [command, command_name]
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
+
+    def task_format?(arg)
+      arg.to_s.match?(/\A\S+:\S*\z/)
     end
 
     def handle_error(error, command_name)

--- a/lib/tomo/cli.rb
+++ b/lib/tomo/cli.rb
@@ -57,7 +57,7 @@ module Tomo
       command_name = Abbrev.abbrev(COMMANDS.keys)[command_name]
       argv.shift if command_name
 
-      # command_name = "run" if command_name.nil? && task_format?(argv.first)
+      command_name = "run" if command_name.nil? && task_format?(argv.first)
       command = COMMANDS[command_name] || Tomo::Commands::Default
       [command, command_name]
     end

--- a/lib/tomo/cli/completions.rb
+++ b/lib/tomo/cli/completions.rb
@@ -6,7 +6,7 @@ module Tomo
       end
 
       def self.active?
-        !!@active
+        defined?(@active) && @active
       end
 
       def initialize(literal: false, stdout: $stdout, exit_proc: nil)

--- a/lib/tomo/commands/default.rb
+++ b/lib/tomo/commands/default.rb
@@ -19,9 +19,13 @@ module Tomo
 
           #{commands.map { |name, help| "  #{yellow(name.ljust(10))} #{help}" }.join("\n")}
 
-          Tomo accepts abbreviations for its commands. For example, #{blue('tomo deploy')}
-          can be shortened to #{blue('tomo d')}. You can use bash completions as well!
-          Run #{blue('tomo completion-script')} for installation instructions.
+          The tomo CLI also provides some convenient shortcuts:
+
+          - Commands can be abbreviated, like #{blue('tomo d')} to run #{blue('tomo deploy')}.
+          - When running tasks, the #{yellow('run')} command is implied and can be omitted.
+            E.g., #{blue('tomo run rails:console')} can be shortened to #{blue('tomo rails:console')}.
+          - Bash completions are also available. Run #{blue('tomo completion-script')} for
+            installation instructions.
 
           For help with any command, add #{blue('-h')} to the command, like this:
 

--- a/lib/tomo/commands/default.rb
+++ b/lib/tomo/commands/default.rb
@@ -10,6 +10,7 @@ module Tomo
 
       include CLI::CommonOptions
 
+      # rubocop:disable Metrics/AbcSize
       def banner
         <<~BANNER
           Usage: #{green('tomo')} #{yellow('COMMAND [options]')}
@@ -36,6 +37,7 @@ module Tomo
             #{blue('https://tomo-deploy.com/')}
         BANNER
       end
+      # rubocop:enable Metrics/AbcSize
 
       def call(*args, options)
         # The bare `tomo` command (i.e. without `--help` or `--version`) doesn't

--- a/lib/tomo/commands/run.rb
+++ b/lib/tomo/commands/run.rb
@@ -34,6 +34,11 @@ module Tomo
 
             #{blue('tomo run core:clean_releases')}
 
+          When you specify a task name, the #{blue('run')} command is implied and can be
+          omitted, so this works as well:
+
+            #{blue('tomo core:clean_releases')}
+
           You can run any task defined by plugins loaded in #{DEFAULT_CONFIG_PATH}.
           To see a list of available tasks, run #{blue('tomo tasks')}.
 

--- a/lib/tomo/testing/local.rb
+++ b/lib/tomo/testing/local.rb
@@ -16,8 +16,8 @@ module Tomo
         Local.with_tomo_gemfile(&block)
       end
 
-      def capture(command, raise_on_error: true)
-        Local.capture(command, raise_on_error: raise_on_error)
+      def capture(*command, raise_on_error: true)
+        Local.capture(*command, raise_on_error: raise_on_error)
       end
 
       class << self
@@ -35,12 +35,13 @@ module Tomo
           Dir.chdir(dir, &block)
         end
 
-        def capture(command, raise_on_error: true)
-          progress(command) do
-            output, status = Open3.capture2e(command)
+        def capture(*command, raise_on_error: true)
+          command_str = command.join(" ")
+          progress(command_str) do
+            output, status = Open3.capture2e(*command)
 
             if raise_on_error && !status.success?
-              raise "Command failed: #{command}\n#{output}"
+              raise "Command failed: #{command_str}\n#{output}"
             end
 
             output

--- a/lib/tomo/testing/local.rb
+++ b/lib/tomo/testing/local.rb
@@ -8,6 +8,18 @@ require "tmpdir"
 module Tomo
   module Testing
     module Local
+      def in_temp_dir(&block)
+        Local.in_temp_dir(&block)
+      end
+
+      def with_tomo_gemfile(&block)
+        Local.with_tomo_gemfile(&block)
+      end
+
+      def capture(command, raise_on_error: true)
+        Local.capture(command, raise_on_error: raise_on_error)
+      end
+
       class << self
         def with_tomo_gemfile
           Bundler.with_original_env do

--- a/test/rails_setup_deploy_e2e_test.rb
+++ b/test/rails_setup_deploy_e2e_test.rb
@@ -4,6 +4,8 @@ require "net/http"
 require "securerandom"
 
 class RailsSetupDeployE2ETest < Minitest::Test
+  include Tomo::Testing::Local
+
   def setup
     @docker = Tomo::Testing::DockerImage.new
     @docker.build_and_run
@@ -44,7 +46,7 @@ class RailsSetupDeployE2ETest < Minitest::Test
   private
 
   def bundle_exec(command)
-    Tomo::Testing::Local.with_tomo_gemfile do
+    with_tomo_gemfile do
       full_cmd = "bundle exec #{command}"
       puts ">>> #{full_cmd}"
       system(full_cmd) || raise("Command failed")
@@ -52,9 +54,9 @@ class RailsSetupDeployE2ETest < Minitest::Test
   end
 
   def in_cloned_rails_repo(&block)
-    Tomo::Testing::Local.in_temp_dir do
+    in_temp_dir do
       repo = "https://github.com/mattbrictson/rails-new.git"
-      Tomo::Testing::Local.capture("git clone #{repo}")
+      capture("git clone #{repo}")
       Dir.chdir("rails-new", &block)
     end
   end

--- a/test/tomo/cli/completions_test.rb
+++ b/test/tomo/cli/completions_test.rb
@@ -17,7 +17,7 @@ class Tomo::CLI::CompletionsTest < Minitest::Test
 
   def tomo(*args)
     with_tomo_gemfile do
-      @stdout = capture(["bundle", "exec", "tomo", *args.flatten].join(" "))
+      @stdout = capture("bundle", "exec", "tomo", *args.flatten)
     end
   end
 end

--- a/test/tomo/cli/completions_test.rb
+++ b/test/tomo/cli/completions_test.rb
@@ -1,10 +1,12 @@
 require "test_helper"
 
 class Tomo::CLI::CompletionsTest < Minitest::Test
+  include Tomo::Testing::Local
+
   def test_completions_include_setting_names
-    output = Tomo::Testing::Local.in_temp_dir do
-      capture "bundle exec tomo init"
-      capture "bundle exec tomo --complete deploy -s"
+    output = in_temp_dir do
+      tomo "init"
+      tomo "--complete", "deploy", "-s"
     end
 
     assert_match(/^git_branch=$/, output)
@@ -13,9 +15,9 @@ class Tomo::CLI::CompletionsTest < Minitest::Test
 
   private
 
-  def capture(command)
-    Tomo::Testing::Local.with_tomo_gemfile do
-      Tomo::Testing::Local.capture(command)
+  def tomo(*args)
+    with_tomo_gemfile do
+      @stdout = capture(["bundle", "exec", "tomo", *args.flatten].join(" "))
     end
   end
 end

--- a/test/tomo/cli/completions_test.rb
+++ b/test/tomo/cli/completions_test.rb
@@ -17,7 +17,7 @@ class Tomo::CLI::CompletionsTest < Minitest::Test
 
   def tomo(*args)
     with_tomo_gemfile do
-      @stdout = capture("bundle", "exec", "tomo", *args.flatten)
+      capture("bundle", "exec", "tomo", *args.flatten)
     end
   end
 end

--- a/test/tomo/cli_test.rb
+++ b/test/tomo/cli_test.rb
@@ -17,7 +17,7 @@ class Tomo::CLITest < Minitest::Test
 
   def tomo(*args)
     with_tomo_gemfile do
-      @stdout = capture(["bundle", "exec", "tomo", *args.flatten].join(" "))
+      @stdout = capture("bundle", "exec", "tomo", *args.flatten)
     end
   end
 end

--- a/test/tomo/cli_test.rb
+++ b/test/tomo/cli_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class Tomo::CLITest < Minitest::Test
+  include Tomo::Testing::Local
+
+  def test_execute_task_with_implicit_run_command
+    in_temp_dir do
+      tomo "init"
+      tomo "bundler:install", "--dry-run"
+      assert_match "Simulated bundler:install", stdout
+    end
+  end
+
+  private
+
+  attr_reader :stdout
+
+  def tomo(*args)
+    with_tomo_gemfile do
+      @stdout = capture(["bundle", "exec", "tomo", *args.flatten].join(" "))
+    end
+  end
+end

--- a/test/tomo/cli_test.rb
+++ b/test/tomo/cli_test.rb
@@ -6,18 +6,16 @@ class Tomo::CLITest < Minitest::Test
   def test_execute_task_with_implicit_run_command
     in_temp_dir do
       tomo "init"
-      tomo "bundler:install", "--dry-run"
+      stdout = tomo "bundler:install", "--dry-run"
       assert_match "Simulated bundler:install", stdout
     end
   end
 
   private
 
-  attr_reader :stdout
-
   def tomo(*args)
     with_tomo_gemfile do
-      @stdout = capture("bundle", "exec", "tomo", *args.flatten)
+      capture("bundle", "exec", "tomo", *args.flatten)
     end
   end
 end


### PR DESCRIPTION
Inspired by `yarn`, this PR modifies `Tomo::CLI` so that the `run` command is implied and can be omitted when running tasks from the command line. This syntax will also be familiar to rake users.

In other words, instead of:

```
$ tomo run rails:console
```

You can now write:

```
$ tomo rails:console
```

The existing `run` syntax will continue to be supported.