### PR TITLE
Allow `bundler:upgrade_bundler` to accept a CLI arg with the desired bundler version

### DIFF
--- a/docs/plugins/bundler.md
+++ b/docs/plugins/bundler.md
@@ -24,6 +24,12 @@ gem install bundler --conservative --no-document -v VERSION
 
 `bundler:upgrade_bundler` is intended for use as a [setup](../commands/setup.md) task. It should be run prior to [bundler:install](#bundlerinstall) to ensure that the correct version bundler is present.
 
+This task can also be used on the command line and accepts the desired bundler version as an optional argument. If given, the task will install the version of bundler specified. If not, it falls back to the implicit `Gemfile.lock` behavior described above. Example usage:
+
+```plain
+$ tomo run bundler:upgrade_bundler 2.0.2
+```
+
 ### bundler:install
 
 Runs `bundle install` to download and install all the dependencies specified by the Gemfile of the app that is being deployed. As a performance optimization, this task will run `bundle check` first to see if the app’s dependencies have already been installed. If so, `bundle install` is skipped.

--- a/lib/tomo/plugin/bundler/tasks.rb
+++ b/lib/tomo/plugin/bundler/tasks.rb
@@ -11,7 +11,8 @@ module Tomo::Plugin::Bundler
     end
 
     def upgrade_bundler
-      needed_bundler_ver = extract_bundler_ver_from_lockfile
+      args = settings[:run_args]
+      needed_bundler_ver = args.first || extract_bundler_ver_from_lockfile
       return if needed_bundler_ver.nil?
 
       remote.run(

--- a/test/tomo/plugin/bundler/tasks_test.rb
+++ b/test/tomo/plugin/bundler/tasks_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+require "tomo/plugin/bundler"
+
+class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
+  def setup
+    @tester = Tomo::Testing::MockPluginTester.new("bundler")
+  end
+
+  def test_upgrade_bundler
+    @tester.mock_script_result(/^tail .*Gemfile\.lock/, stdout: <<~OUT)
+        minitest-ci (~> 3.4)
+        minitest-hooks (~> 1.5)
+        minitest-reporters (~> 1.3)
+        rake (~> 12.3)
+        rubocop (= 0.73.0)
+        rubocop-performance (= 1.4.0)
+        tomo!
+
+      BUNDLED WITH
+         2.0.2
+    OUT
+    @tester.run_task("bundler:upgrade_bundler")
+    assert_equal(
+      "gem install bundler --conservative --no-document -v 2.0.2",
+      @tester.executed_scripts.last
+    )
+  end
+
+  def test_upgrade_bundler_skips_installation_if_lock_file_is_absent
+    @tester.mock_script_result(/^tail .*Gemfile\.lock/, exit_status: 1)
+    @tester.run_task("bundler:upgrade_bundler")
+    assert_match(/tail .*Gemfile\.lock/, @tester.executed_script)
+  end
+
+  def test_upgrade_bundler_with_explicit_version_arg
+    @tester.run_task("bundler:upgrade_bundler", "3.0.0")
+    assert_equal(
+      "gem install bundler --conservative --no-document -v 3.0.0",
+      @tester.executed_script
+    )
+  end
+end


### PR DESCRIPTION
Normally `bundler:upgrade_bundler` guesses the version of bundler to install based on the contents of `Gemfile.lock`. However there are some scenarios, such as when you are preparing the remote host for a future deployment, where you might want to install a version other than the current version in the `Gemfile.lock`.

This PR facilitates this by making it possible to specify the desired version of bundler on the command like when using `tomo run`, like this:

```
# Install bundler 2.0.2
$ tomo run bundler:upgrade_bundler 2.0.2
```