### PR TITLE
Enable bash completions for new `tomo TASK` CLI style

### DIFF
--- a/lib/tomo/commands/default.rb
+++ b/lib/tomo/commands/default.rb
@@ -56,7 +56,7 @@ module Tomo
 
       def raise_unrecognized_command(command)
         error = "#{yellow(command)} is not a recognized tomo command."
-        if command.match?(/\A\S+:\S+\z/)
+        if command.match?(/\A\S+:/)
           suggestion = "tomo run #{command}"
           error << "\nMaybe you meant #{blue(suggestion)}?"
         end

--- a/test/tomo/cli/completions_test.rb
+++ b/test/tomo/cli/completions_test.rb
@@ -13,6 +13,16 @@ class Tomo::CLI::CompletionsTest < Minitest::Test
     assert_match(/^git_url=$/, output)
   end
 
+  def test_completes_task_name_even_without_run_command
+    output = in_temp_dir do
+      tomo "init"
+      tomo "--complete-word", "rails:"
+    end
+
+    assert_match(/^console $/, output)
+    assert_match(/^db_migrate $/, output)
+  end
+
   private
 
   def tomo(*args)


### PR DESCRIPTION
Before, `tomo run TASK` would offer bash completions for the TASK argument, but this did not work for `tomo TASK`.

This commit now makes it is possible to get bash completions once a `:` is typed and therefore tomo is able to guess that the user is typing a task name as opposed to another tomo command.

So for example:

```
$ tomo rails:<TAB>
assets_precompile   db_create           db_schema_load      db_setup            log_tail
console             db_migrate          db_seed             db_structure_load
```