### PR TITLE
Make CLI tests faster and easier to write

### DIFF
--- a/lib/tomo/cli.rb
+++ b/lib/tomo/cli.rb
@@ -19,6 +19,10 @@ module Tomo
 
     class << self
       attr_accessor :show_backtrace
+
+      def exit(status=true)
+        Process.exit(status)
+      end
     end
 
     COMMANDS = {
@@ -74,7 +78,7 @@ module Tomo
       error.command_name = command_name if error.respond_to?(:command_name=)
       Tomo.logger.error(error.to_console)
       status = error.respond_to?(:exit_status) ? error.exit_status : 1
-      exit(status) unless Tomo::CLI.show_backtrace
+      CLI.exit(status) unless Tomo::CLI.show_backtrace
 
       raise error
     end

--- a/lib/tomo/cli/common_options.rb
+++ b/lib/tomo/cli/common_options.rb
@@ -21,7 +21,7 @@ module Tomo
           end
           option :help, "-h, --help", "Print this documentation" do |_help|
             puts instance_variable_get(:@parser)
-            exit
+            CLI.exit
           end
 
           after_parse :dump_runtime_info

--- a/lib/tomo/cli/completions.rb
+++ b/lib/tomo/cli/completions.rb
@@ -17,7 +17,7 @@ module Tomo
       def print_completions_and_exit(rules, *args, state:)
         completions = completions_for(rules, *args, state)
         words = completions.map { |c| bash_word_for(c, args.last) }
-        stdout.puts(words.join("\n")) unless words.empty?
+        Tomo.logger.info(words.join("\n")) unless words.empty?
         CLI.exit
       end
 

--- a/lib/tomo/cli/completions.rb
+++ b/lib/tomo/cli/completions.rb
@@ -9,22 +9,21 @@ module Tomo
         defined?(@active) && @active
       end
 
-      def initialize(literal: false, stdout: $stdout, exit_proc: nil)
+      def initialize(literal: false, stdout: $stdout)
         @literal = literal
         @stdout = stdout
-        @exit_proc = exit_proc || Kernel.method(:exit)
       end
 
       def print_completions_and_exit(rules, *args, state:)
         completions = completions_for(rules, *args, state)
         words = completions.map { |c| bash_word_for(c, args.last) }
         stdout.puts(words.join("\n")) unless words.empty?
-        exit_proc.call
+        CLI.exit
       end
 
       private
 
-      attr_reader :literal, :stdout, :exit_proc
+      attr_reader :literal, :stdout
 
       def completions_for(rules, *prefix_args, word, state)
         all_candidates(rules, prefix_args, state).select do |cand|

--- a/lib/tomo/commands/default.rb
+++ b/lib/tomo/commands/default.rb
@@ -5,7 +5,7 @@ module Tomo
 
       option :version, "-v, --version", "Display tomo’s version and exit" do
         Version.parse([])
-        exit
+        CLI.exit
       end
 
       include CLI::CommonOptions

--- a/lib/tomo/commands/init.rb
+++ b/lib/tomo/commands/init.rb
@@ -46,14 +46,14 @@ module Tomo
         return unless File.exist?(".tomo")
 
         logger.error("Can't create .tomo directory; a file already exists")
-        exit(1)
+        CLI.exit(1)
       end
 
       def assert_no_tomo_project!
         return unless File.exist?(DEFAULT_CONFIG_PATH)
 
         logger.error("A #{DEFAULT_CONFIG_PATH} file already exists")
-        exit(1)
+        CLI.exit(1)
       end
 
       def current_dir_name

--- a/lib/tomo/ssh/connection.rb
+++ b/lib/tomo/ssh/connection.rb
@@ -9,7 +9,7 @@ module Tomo
         new(
           host,
           options,
-          exec_proc: proc { exit(0) },
+          exec_proc: proc { CLI.exit },
           child_proc: proc { Result.empty_success }
         )
       end

--- a/lib/tomo/testing.rb
+++ b/lib/tomo/testing.rb
@@ -9,6 +9,7 @@ module Tomo
     autoload :DockerPluginTester, "tomo/testing/docker_plugin_tester"
     autoload :HostExtensions, "tomo/testing/host_extensions"
     autoload :Local, "tomo/testing/local"
+    autoload :LogCapturing, "tomo/testing/log_capturing"
     autoload :MockedExecError, "tomo/testing/mocked_exec_error"
     autoload :MockedExitError, "tomo/testing/mocked_exit_error"
     autoload :MockPluginTester, "tomo/testing/mock_plugin_tester"

--- a/lib/tomo/testing.rb
+++ b/lib/tomo/testing.rb
@@ -3,6 +3,7 @@ require "tomo"
 module Tomo
   module Testing
     autoload :CLIExtensions, "tomo/testing/cli_extensions"
+    autoload :CLITester, "tomo/testing/cli_tester"
     autoload :Connection, "tomo/testing/connection"
     autoload :DockerImage, "tomo/testing/docker_image"
     autoload :DockerPluginTester, "tomo/testing/docker_plugin_tester"

--- a/lib/tomo/testing.rb
+++ b/lib/tomo/testing.rb
@@ -2,12 +2,14 @@ require "tomo"
 
 module Tomo
   module Testing
+    autoload :CLIExtensions, "tomo/testing/cli_extensions"
     autoload :Connection, "tomo/testing/connection"
     autoload :DockerImage, "tomo/testing/docker_image"
     autoload :DockerPluginTester, "tomo/testing/docker_plugin_tester"
     autoload :HostExtensions, "tomo/testing/host_extensions"
     autoload :Local, "tomo/testing/local"
     autoload :MockedExecError, "tomo/testing/mocked_exec_error"
+    autoload :MockedExitError, "tomo/testing/mocked_exit_error"
     autoload :MockPluginTester, "tomo/testing/mock_plugin_tester"
     autoload :PluginTester, "tomo/testing/plugin_tester"
     autoload :RemoteExtensions, "tomo/testing/remote_extensions"
@@ -31,6 +33,9 @@ end
 Tomo.logger = Tomo::Logger.new(
   stdout: File.open(File::NULL, "w"), stderr: File.open(File::NULL, "w")
 )
+class << Tomo::CLI
+  prepend Tomo::Testing::CLIExtensions
+end
 Tomo::Colors.enabled = false
 Tomo::Host.prepend Tomo::Testing::HostExtensions
 Tomo::Remote.prepend Tomo::Testing::RemoteExtensions

--- a/lib/tomo/testing/cli_extensions.rb
+++ b/lib/tomo/testing/cli_extensions.rb
@@ -1,0 +1,9 @@
+module Tomo
+  module Testing
+    module CLIExtensions
+      def exit(status=true)
+        raise MockedExitError, status
+      end
+    end
+  end
+end

--- a/lib/tomo/testing/cli_tester.rb
+++ b/lib/tomo/testing/cli_tester.rb
@@ -4,6 +4,7 @@ module Tomo
   module Testing
     class CLITester
       include Local
+      include LogCapturing
 
       def initialize
         @token = SecureRandom.hex(8)
@@ -21,14 +22,6 @@ module Tomo
         end
       end
 
-      def stdout
-        @stdout_io&.string
-      end
-
-      def stderr
-        @stderr_io&.string
-      end
-
       private
 
       attr_reader :token
@@ -40,17 +33,6 @@ module Tomo
         Tomo.dry_run = false
         Tomo::CLI.show_backtrace = false
         Tomo::CLI::Completions.instance_variable_set(:@active, false)
-      end
-
-      # TODO: move to mixin
-      def capturing_logger_output
-        orig_logger = Tomo.logger
-        @stdout_io = StringIO.new
-        @stderr_io = StringIO.new
-        Tomo.logger = Tomo::Logger.new(stdout: @stdout_io, stderr: @stderr_io)
-        yield
-      ensure
-        Tomo.logger = orig_logger
       end
 
       def handling_exit(raise_on_error)

--- a/lib/tomo/testing/cli_tester.rb
+++ b/lib/tomo/testing/cli_tester.rb
@@ -1,0 +1,63 @@
+require "securerandom"
+
+module Tomo
+  module Testing
+    class CLITester
+      include Local
+
+      def initialize
+        @token = SecureRandom.hex(8)
+      end
+
+      def run(*args, raise_on_error: true)
+        in_temp_dir(token) do
+          restoring_defaults do
+            capturing_logger_output do
+              handling_exit(raise_on_error) do
+                CLI.new.call(args.flatten)
+              end
+            end
+          end
+        end
+      end
+
+      def stdout
+        @stdout_io&.string
+      end
+
+      def stderr
+        @stderr_io&.string
+      end
+
+      private
+
+      attr_reader :token
+
+      def restoring_defaults
+        yield
+      ensure
+        Tomo.debug = false
+        Tomo.dry_run = false
+        Tomo::CLI.show_backtrace = false
+        Tomo::CLI::Completions.instance_variable_set(:@active, false)
+      end
+
+      # TODO: move to mixin
+      def capturing_logger_output
+        orig_logger = Tomo.logger
+        @stdout_io = StringIO.new
+        @stderr_io = StringIO.new
+        Tomo.logger = Tomo::Logger.new(stdout: @stdout_io, stderr: @stderr_io)
+        yield
+      ensure
+        Tomo.logger = orig_logger
+      end
+
+      def handling_exit(raise_on_error)
+        yield
+      rescue Tomo::Testing::MockedExitError => e
+        raise if raise_on_error && !e.success?
+      end
+    end
+  end
+end

--- a/lib/tomo/testing/local.rb
+++ b/lib/tomo/testing/local.rb
@@ -8,12 +8,12 @@ require "tmpdir"
 module Tomo
   module Testing
     module Local
-      def in_temp_dir(&block)
-        Local.in_temp_dir(&block)
-      end
-
       def with_tomo_gemfile(&block)
         Local.with_tomo_gemfile(&block)
+      end
+
+      def in_temp_dir(token=nil, &block)
+        Local.in_temp_dir(token, &block)
       end
 
       def capture(*command, raise_on_error: true)
@@ -29,8 +29,9 @@ module Tomo
           end
         end
 
-        def in_temp_dir(&block)
-          dir = File.join(Dir.tmpdir, "tomo_test_#{SecureRandom.hex(8)}")
+        def in_temp_dir(token=nil, &block)
+          token ||= SecureRandom.hex(8)
+          dir = File.join(Dir.tmpdir, "tomo_test_#{token}")
           FileUtils.mkdir_p(dir)
           Dir.chdir(dir, &block)
         end

--- a/lib/tomo/testing/log_capturing.rb
+++ b/lib/tomo/testing/log_capturing.rb
@@ -1,0 +1,25 @@
+module Tomo
+  module Testing
+    module LogCapturing
+      def stdout
+        @stdout_io&.string
+      end
+
+      def stderr
+        @stderr_io&.string
+      end
+
+      private
+
+      def capturing_logger_output
+        orig_logger = Tomo.logger
+        @stdout_io = StringIO.new
+        @stderr_io = StringIO.new
+        Tomo.logger = Tomo::Logger.new(stdout: @stdout_io, stderr: @stderr_io)
+        yield
+      ensure
+        Tomo.logger = orig_logger
+      end
+    end
+  end
+end

--- a/lib/tomo/testing/mocked_exit_error.rb
+++ b/lib/tomo/testing/mocked_exit_error.rb
@@ -1,0 +1,16 @@
+module Tomo
+  module Testing
+    class MockedExitError < Exception # rubocop:disable Lint/InheritException
+      attr_reader :status
+
+      def initialize(status)
+        @status = status
+        super("tomo exited with status #{status}")
+      end
+
+      def success?
+        status == true || status == 0 # rubocop:disable Style/NumericPredicate
+      end
+    end
+  end
+end

--- a/lib/tomo/testing/plugin_tester.rb
+++ b/lib/tomo/testing/plugin_tester.rb
@@ -1,6 +1,8 @@
 module Tomo
   module Testing
     class PluginTester
+      include LogCapturing
+
       def initialize(*plugin_names, settings: {}, host:)
         @host = host
         config = Configuration.new
@@ -23,27 +25,9 @@ module Tomo
         end
       end
 
-      def stdout
-        @stdout_io&.string
-      end
-
-      def stderr
-        @stderr_io&.string
-      end
-
       private
 
       attr_reader :host, :runtime
-
-      def capturing_logger_output
-        orig_logger = Tomo.logger
-        @stdout_io = StringIO.new
-        @stderr_io = StringIO.new
-        Tomo.logger = Tomo::Logger.new(stdout: @stdout_io, stderr: @stderr_io)
-        yield
-      ensure
-        Tomo.logger = orig_logger
-      end
     end
   end
 end

--- a/test/tomo/cli/completions_test.rb
+++ b/test/tomo/cli/completions_test.rb
@@ -1,57 +1,23 @@
 require "test_helper"
 
 class Tomo::CLI::CompletionsTest < Minitest::Test
-  include Tomo::Testing::Local
+  def setup
+    @tester = Tomo::Testing::CLITester.new
+  end
 
   def test_completions_include_setting_names
-    output, _stderr = in_temp_dir do
-      tomo "init"
-      tomo "--complete", "deploy", "-s"
-    end
+    @tester.run "init"
+    @tester.run "--complete", "deploy", "-s"
 
-    assert_match(/^git_branch=$/, output)
-    assert_match(/^git_url=$/, output)
+    assert_match(/^git_branch=$/, @tester.stdout)
+    assert_match(/^git_url=$/, @tester.stdout)
   end
 
   def test_completes_task_name_even_without_run_command
-    output, _stderr = in_temp_dir do
-      tomo "init"
-      tomo "--complete-word", "rails:"
-    end
+    @tester.run "init"
+    @tester.run "--complete-word", "rails:"
 
-    assert_match(/^console $/, output)
-    assert_match(/^db_migrate $/, output)
-  end
-
-  private
-
-  def tomo(*args)
-    capturing_logger_output do
-      handling_exit do
-        Tomo::CLI.new.call(args.flatten)
-      end
-    end
-  ensure
-    Tomo.debug = false
-    Tomo.dry_run = false
-    Tomo::CLI.show_backtrace = false
-    Tomo::CLI::Completions.instance_variable_set(:@active, false)
-  end
-
-  def handling_exit
-    yield
-  rescue Tomo::Testing::MockedExitError => e
-    raise unless e.success?
-  end
-
-  def capturing_logger_output
-    orig_logger = Tomo.logger
-    stdout_io = StringIO.new
-    stderr_io = StringIO.new
-    Tomo.logger = Tomo::Logger.new(stdout: stdout_io, stderr: stderr_io)
-    yield
-    [stdout_io.string, stderr_io.string]
-  ensure
-    Tomo.logger = orig_logger
+    assert_match(/^console $/, @tester.stdout)
+    assert_match(/^db_migrate $/, @tester.stdout)
   end
 end

--- a/test/tomo/cli_test.rb
+++ b/test/tomo/cli_test.rb
@@ -1,37 +1,13 @@
 require "test_helper"
 
 class Tomo::CLITest < Minitest::Test
-  include Tomo::Testing::Local
+  def setup
+    @tester = Tomo::Testing::CLITester.new
+  end
 
   def test_execute_task_with_implicit_run_command
-    in_temp_dir do
-      tomo "init"
-      stdout, _stderr = tomo "bundler:install", "--dry-run"
-      assert_match "Simulated bundler:install", stdout
-    end
-  end
-
-  private
-
-  def tomo(*args)
-    capturing_logger_output do
-      Tomo::CLI.new.call(args.flatten)
-    end
-  ensure
-    Tomo.debug = false
-    Tomo.dry_run = false
-    Tomo::CLI.show_backtrace = false
-    Tomo::CLI::Completions.instance_variable_set(:@active, false)
-  end
-
-  def capturing_logger_output
-    orig_logger = Tomo.logger
-    stdout_io = StringIO.new
-    stderr_io = StringIO.new
-    Tomo.logger = Tomo::Logger.new(stdout: stdout_io, stderr: stderr_io)
-    yield
-    [stdout_io.string, stderr_io.string]
-  ensure
-    Tomo.logger = orig_logger
+    @tester.run "init"
+    @tester.run "bundler:install", "--dry-run"
+    assert_match "Simulated bundler:install", @tester.stdout
   end
 end


### PR DESCRIPTION
Before, there was no "official" way to write CLI tests, but the few we had involved running tomo via `bundle exec tomo` in a completely separate process and capturing the output. This is awkward and slow. Why not just invoke the `CLI#run` method directly and test that way?

Turns out it is not that easy, because among other things, the CLI might call `Process.exit`, killing the entire test harness.

This PR makes CLI testing easy (and about 2x faster than `bundle exec tomo`) by introducing a `CLITester` helper class. This class handles:

* capturing output for easy inspection after the CLI has run
* gracefully handling when the CLI exits
* restoring any global variables that were altered by the CLI so that other tests aren't affected

To make this possible, any direct uses of `Process.exit` in the codebase were replaced with `Tomo::CLI.exit`, which is overridden during testing to prevent the Ruby process from being killed.

Also the log capturing concern was refactored into a `LogCapturing` mixin.