### PR TITLE
Allow bundler version to specified via setting

### DIFF
--- a/docs/plugins/bundler.md
+++ b/docs/plugins/bundler.md
@@ -4,31 +4,26 @@ The bundler plugin installs ruby gem dependencies using bundler. This is require
 
 ## Settings
 
-| Name                    | Purpose                                                             | Default                   |
-| ----------------------- | ------------------------------------------------------------------- | ------------------------- |
-| `bundler_install_flags` | Array of command-line flags to pass to the `bundle install` command | `["--deployment"]`        |
-| `bundler_gemfile`       | Optionally used to override the location of the Gemfile             | `nil`                     |
-| `bundler_jobs`          | Amount of concurrency used when downloading/installing gems         | `"4"`                     |
-| `bundler_path`          | Directory where gems where be installed                             | `"%<shared_path>/bundle"` |
-| `bundler_without`       | Array of Gemfile groups to exclude from installation                | `["development", "test"]` |
+| Name                    | Purpose                                                                                                                                                                       | Default                   |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `bundler_install_flags` | Array of command-line flags to pass to the `bundle install` command                                                                                                           | `["--deployment"]`        |
+| `bundler_gemfile`       | Optionally used to override the location of the Gemfile                                                                                                                       | `nil`                     |
+| `bundler_jobs`          | Amount of concurrency used when downloading/installing gems                                                                                                                   | `"4"`                     |
+| `bundler_path`          | Directory where gems where be installed                                                                                                                                       | `"%<shared_path>/bundle"` |
+| `bundler_version`       | The version of bundler to install, used by the [bundler:upgrade_bundler](#bundlerupgrade_bundler) task; if `nil` (the default), determine the version based on `Gemfile.lock` | `nil`                     |
+| `bundler_without`       | Array of Gemfile groups to exclude from installation                                                                                                                          | `["development", "test"]` |
 
 ## Tasks
 
 ### bundler:upgrade_bundler
 
-Installs the version of bundler required by the app that is being deployed. The version is determined by looking at the `BUNDLED WITH` entry within the app’s `Gemfile.lock`. If the app is missing a lockfile this task does nothing. Bundler will be installed withing this command:
+Installs the version of bundler specified by the `:bundler_version` setting, if specified. If `:bundler_version` is `nil` (the default), this task will automatically determine the version of bundler required by the app that is being deployed by looking at the `BUNDLED WITH` entry within the app’s `Gemfile.lock`. If `:bundler_version` is `nil` and the app is missing a lockfile, then this task does nothing. Bundler will be installed withing this command:
 
 ```
 gem install bundler --conservative --no-document -v VERSION
 ```
 
 `bundler:upgrade_bundler` is intended for use as a [setup](../commands/setup.md) task. It should be run prior to [bundler:install](#bundlerinstall) to ensure that the correct version bundler is present.
-
-This task can also be used on the command line and accepts the desired bundler version as an optional argument. If given, the task will install the version of bundler specified. If not, it falls back to the implicit `Gemfile.lock` behavior described above. Example usage:
-
-```plain
-$ tomo run bundler:upgrade_bundler 2.0.2
-```
 
 ### bundler:install
 

--- a/lib/tomo/plugin/bundler.rb
+++ b/lib/tomo/plugin/bundler.rb
@@ -12,6 +12,7 @@ module Tomo::Plugin
              bundler_gemfile:       nil,
              bundler_jobs:          "4",
              bundler_path:          "%<shared_path>/bundle",
+             bundler_version:       nil,
              bundler_without:       %w[development test]
   end
 end

--- a/lib/tomo/plugin/bundler/tasks.rb
+++ b/lib/tomo/plugin/bundler/tasks.rb
@@ -11,8 +11,7 @@ module Tomo::Plugin::Bundler
     end
 
     def upgrade_bundler
-      args = settings[:run_args]
-      needed_bundler_ver = args.first || extract_bundler_ver_from_lockfile
+      needed_bundler_ver = version_setting || extract_bundler_ver_from_lockfile
       return if needed_bundler_ver.nil?
 
       remote.run(
@@ -23,6 +22,10 @@ module Tomo::Plugin::Bundler
     end
 
     private
+
+    def version_setting
+      settings[:bundler_version]
+    end
 
     def check_options
       gemfile = settings[:bundler_gemfile]

--- a/test/tomo/plugin/bundler/tasks_test.rb
+++ b/test/tomo/plugin/bundler/tasks_test.rb
@@ -2,12 +2,9 @@ require "test_helper"
 require "tomo/plugin/bundler"
 
 class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
-  def setup
-    @tester = Tomo::Testing::MockPluginTester.new("bundler")
-  end
-
-  def test_upgrade_bundler
-    @tester.mock_script_result(/^tail .*Gemfile\.lock/, stdout: <<~OUT)
+  def test_upgrade_bundler_uses_lock_file_for_version
+    tester = configure
+    tester.mock_script_result(/^tail .*Gemfile\.lock/, stdout: <<~OUT)
         minitest-ci (~> 3.4)
         minitest-hooks (~> 1.5)
         minitest-reporters (~> 1.3)
@@ -19,24 +16,32 @@ class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
       BUNDLED WITH
          2.0.2
     OUT
-    @tester.run_task("bundler:upgrade_bundler")
+    tester.run_task("bundler:upgrade_bundler")
     assert_equal(
       "gem install bundler --conservative --no-document -v 2.0.2",
-      @tester.executed_scripts.last
+      tester.executed_scripts.last
+    )
+  end
+
+  def test_upgrade_bundler_uses_setting_for_version
+    tester = configure(bundler_version: "2.0.1")
+    tester.run_task("bundler:upgrade_bundler")
+    assert_equal(
+      "gem install bundler --conservative --no-document -v 2.0.1",
+      tester.executed_script
     )
   end
 
   def test_upgrade_bundler_skips_installation_if_lock_file_is_absent
-    @tester.mock_script_result(/^tail .*Gemfile\.lock/, exit_status: 1)
-    @tester.run_task("bundler:upgrade_bundler")
-    assert_match(/tail .*Gemfile\.lock/, @tester.executed_script)
+    tester = configure
+    tester.mock_script_result(/^tail .*Gemfile\.lock/, exit_status: 1)
+    tester.run_task("bundler:upgrade_bundler")
+    assert_match(/tail .*Gemfile\.lock/, tester.executed_script)
   end
 
-  def test_upgrade_bundler_with_explicit_version_arg
-    @tester.run_task("bundler:upgrade_bundler", "3.0.0")
-    assert_equal(
-      "gem install bundler --conservative --no-document -v 3.0.0",
-      @tester.executed_script
-    )
+  private
+
+  def configure(settings={})
+    Tomo::Testing::MockPluginTester.new("bundler", settings: settings)
   end
 end


### PR DESCRIPTION
Before, the `bundler:upgrade_bundler` task would work by checking the `Gemfile.lock` to determine the version of bundler to install. Sometimes we want to specify the version explicitly instead of relying on this magic.

In an earlier commit, support for manually specifying a bundler version was done via a command-line argument, but this is not consistent with other tomo plugins. Other plugins like nvm and rbenv have a setting that controls the version. The nice thing about this is settings also work on the command line via the `-s` option, so it is a nice solution that supports both styles.

This commit adds a `:bundler_version` setting for this purpose. If the setting is `nil` (the default), it falls back to the auto-detect behavior that existed previously. For consistency, the `:run_args` solution introduced in the earlier commit has been removed.