### PR TITLE
Fix hang when starting puma 4.1.0

### DIFF
--- a/docs/plugins/puma.md
+++ b/docs/plugins/puma.md
@@ -4,10 +4,12 @@ The puma plugin provides basic, zero-configuration support for the default Rails
 
 ## Settings
 
-| Name                 | Purpose                                                      | Default                  |
-| -------------------- | ------------------------------------------------------------ | ------------------------ |
-| `puma_control_token` | Auth token to use when connecting to the puma control server | `"tomo"`                 |
-| `puma_control_url`   | Connection URL for the puma control server                   | `"tcp://127.0.0.1:9293"` |
+| Name                 | Purpose                                                      | Default                         |
+| -------------------- | ------------------------------------------------------------ | ------------------------------- |
+| `puma_control_token` | Auth token to use when connecting to the puma control server | `"tomo"`                        |
+| `puma_control_url`   | Connection URL for the puma control server                   | `"tcp://127.0.0.1:9293"`        |
+| `puma_stdout_path`   | File where puma's stdout will be written                     | `"%<shared_path>/log/puma.out"` |
+| `puma_stderr_path`   | File where puma's stderr will be written                     | `"%<shared_path>/log/puma.err"` |
 
 ## Tasks
 

--- a/lib/tomo/plugin/puma.rb
+++ b/lib/tomo/plugin/puma.rb
@@ -7,6 +7,8 @@ module Tomo::Plugin
     tasks Tomo::Plugin::Puma::Tasks
 
     defaults puma_control_token: "tomo",
-             puma_control_url: "tcp://127.0.0.1:9293"
+             puma_control_url: "tcp://127.0.0.1:9293",
+             puma_stderr_path: "%<shared_path>/log/puma.err",
+             puma_stdout_path: "%<shared_path>/log/puma.out"
   end
 end

--- a/lib/tomo/plugin/puma/tasks.rb
+++ b/lib/tomo/plugin/puma/tasks.rb
@@ -3,10 +3,8 @@ module Tomo::Plugin::Puma
     def restart
       return if try_restart
 
-      remote.chdir(paths.current) do
-        logger.info "Puma is not running. Starting it now."
-        remote.bundle("exec", "puma", "--daemon", *control_options)
-      end
+      logger.info "Puma is not running. Starting it now."
+      start
     end
 
     private
@@ -24,6 +22,25 @@ module Tomo::Plugin::Puma
 
       logger.info(ctl_result.output)
       true
+    end
+
+    def start
+      require_settings :puma_stdout_path, :puma_stderr_path
+
+      ensure_output_directory
+
+      remote.chdir(paths.current) do
+        remote.bundle(
+          "exec", "puma", "--daemon", *control_options,
+          raw(">"), paths.puma_stdout,
+          raw("2>"), paths.puma_stderr
+        )
+      end
+    end
+
+    def ensure_output_directory
+      dirs = [paths.puma_stdout, paths.puma_stderr].map(&:dirname).map(&:to_s)
+      remote.mkdir_p dirs.uniq
     end
 
     def control_options

--- a/test/tomo/plugin/puma/tasks_test.rb
+++ b/test/tomo/plugin/puma/tasks_test.rb
@@ -9,7 +9,9 @@ class Tomo::Plugin::Puma::TasksTest < Minitest::Test
       settings: {
         current_path: "/app/current",
         puma_control_url: "tcp://127.0.0.1:9293",
-        puma_control_token: "test"
+        puma_control_token: "test",
+        puma_stdout_path: "/log/puma.out",
+        puma_stderr_path: "/log/puma.err"
       }
     )
   end
@@ -26,9 +28,11 @@ class Tomo::Plugin::Puma::TasksTest < Minitest::Test
   def test_restart_starts_puma_if_pumactl_fails
     @tester.mock_script_result(/pumactl/, exit_status: 1)
     @tester.run_task("puma:restart")
+    assert_equal("mkdir -p /log", @tester.executed_scripts[-2])
     assert_equal(
       "cd /app/current && bundle exec puma --daemon "\
-      "--control-url tcp://127.0.0.1:9293 --control-token test",
+      "--control-url tcp://127.0.0.1:9293 --control-token test "\
+      "> /log/puma.out 2> /log/puma.err",
       @tester.executed_scripts.last
     )
   end


### PR DESCRIPTION
Puma 4.1.0 no longer flushes stdout before daemonizing. This causes tomo to hang indefinitely after calling `puma --daemon` because the SSH connection does not cleanly exit.

Fix by explicitly redirecting stdout and stderr to files. This has an added benefit of storing troubleshooting information in cases where puma fails to start for other reasons.