### PR TITLE
Link directories needed by puma (Rails 6 support)

### DIFF
--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -32,6 +32,9 @@ set linked_dirs: %w[
   log
   node_modules
   public/assets
+  tmp/cache
+  tmp/pids
+  tmp/sockets
 ]
 
 setup do


### PR DESCRIPTION
Starting in Rails 6.0.0, the puma configuration that ships with Rails assumes that the `tmp/pids` directory exists. This is not the case with a default deploy.

Support Rails 6 by linking `tmp/cache`, `tmp/pids`, and `tmp/sockets` by default, so these directories are guaranteed to exist and are shared between releases.