### PR TITLE
Enable RAILS_SERVE_STATIC_FILES by default

### DIFF
--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -22,8 +22,9 @@ set git_exclusions: %w[
   test/
 ]
 set env_vars: {
-  RAILS_ENV: "production",
   RACK_ENV: "production",
+  RAILS_ENV: "production",
+  RAILS_SERVE_STATIC_FILES: "1",
   DATABASE_URL: :prompt,
   SECRET_KEY_BASE: :prompt
 }


### PR DESCRIPTION
Most simple deploys of Rails do not involve Nginx/Apache, and therefore files in `public/` (including CSS and JS) will not be served unless `RAILS_SERVE_STATIC_FILES` is enabled.

This commit enables this env var by default for new tomo projects.