### PR TITLE
Handle nil path settings more consistently

### DIFF
--- a/lib/tomo/paths.rb
+++ b/lib/tomo/paths.rb
@@ -29,6 +29,8 @@ module Tomo
     end
 
     def path(setting)
+      return nil if settings[setting].nil?
+
       path = settings.fetch(setting).to_s.gsub(%r{//+}, "/")
       Path.new(path)
     end

--- a/test/tomo/paths_test.rb
+++ b/test/tomo/paths_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Tomo::PathsTest < Minitest::Test
+  def test_raises_if_setting_does_not_exist
+    paths = Tomo::Paths.new({})
+    assert_raises(NoMethodError) { paths.storage }
+  end
+
+  def test_returns_nil_if_setting_is_nil
+    paths = Tomo::Paths.new(storage_path: nil)
+    assert_nil(paths.storage)
+  end
+end


### PR DESCRIPTION
Before, if a path setting was `nil`, accessing that setting via the `paths` DSL would return an empty string, which is inconsistent. Now the DSL will also return `nil` in that scenario.