### PR TITLE
Explicitly configure bundler with a .bundle/config file rather than relying on side effects of bundle install flags (Bundler 3 support)

### DIFF
--- a/docs/commands/setup.md
+++ b/docs/commands/setup.md
@@ -37,6 +37,7 @@ setup do
   run "nodenv:install"
   run "rbenv:install"
   run "bundler:upgrade_bundler"
+  run "bundler:config"
   run "bundler:install"
   run "rails:db_create"
   run "rails:db_schema_load"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,6 +182,7 @@ setup do
   run "nodenv:install"
   run "rbenv:install"
   run "bundler:upgrade_bundler"
+  run "bundler:config"
   run "bundler:install"
   run "rails:db_create"
   run "rails:db_schema_load"

--- a/docs/plugins/bundler.md
+++ b/docs/plugins/bundler.md
@@ -4,14 +4,19 @@ The bundler plugin installs ruby gem dependencies using bundler. This is require
 
 ## Settings
 
-| Name                    | Purpose                                                                                                                                                                       | Default                   |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| `bundler_install_flags` | Array of command-line flags to pass to the `bundle install` command                                                                                                           | `["--deployment"]`        |
-| `bundler_gemfile`       | Optionally used to override the location of the Gemfile                                                                                                                       | `nil`                     |
-| `bundler_jobs`          | Amount of concurrency used when downloading/installing gems                                                                                                                   | `"4"`                     |
-| `bundler_path`          | Directory where gems where be installed                                                                                                                                       | `"%<shared_path>/bundle"` |
-| `bundler_version`       | The version of bundler to install, used by the [bundler:upgrade_bundler](#bundlerupgrade_bundler) task; if `nil` (the default), determine the version based on `Gemfile.lock` | `nil`                     |
-| `bundler_without`       | Array of Gemfile groups to exclude from installation                                                                                                                          | `["development", "test"]` |
+Note that the settings listed here only take effect if you run the [bundler:config](#bundlerconfig) task.
+
+| Name                  | Purpose                                                                                                                                                                       | Default                   |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `bundler_config_path` | Location where the [bundler:config](#bundlerconfig) task will write bundler's configuration file                                                                              | `".bundle/config"`        |
+| `bundler_deployment`  | Enables bundler's [deployment mode](https://bundler.io/v2.0/man/bundle-install.1.html#DEPLOYMENT-MODE) (strongly recommended)                                                 | `true`                    |
+| `bundler_gemfile`     | Optionally used to override the location of the Gemfile                                                                                                                       | `nil`                     |
+| `bundler_jobs`        | Amount of concurrency used when downloading/installing gems                                                                                                                   | `"4"`                     |
+| `bundler_path`        | Directory where gems where be installed                                                                                                                                       | `"%<shared_path>/bundle"` |
+| `bundler_retry`       | Number of times to retry installing a gem if it fails to download                                                                                                             | `"3"`                     |
+| `bundler_version`     | The version of bundler to install, used by the [bundler:upgrade_bundler](#bundlerupgrade_bundler) task; if `nil` (the default), determine the version based on `Gemfile.lock` | `nil`                     |
+| `bundler_with`        | Array of Gemfile groups to install (empty implies all groups)                                                                                                                 | `[]`                      |
+| `bundler_without`     | Array of Gemfile groups to exclude from installation                                                                                                                          | `["development", "test"]` |
 
 ## Tasks
 
@@ -24,6 +29,12 @@ gem install bundler --conservative --no-document -v VERSION
 ```
 
 `bundler:upgrade_bundler` is intended for use as a [setup](../commands/setup.md) task. It should be run prior to [bundler:install](#bundlerinstall) to ensure that the correct version bundler is present.
+
+### bundler:config
+
+Writes a `.bundle/config` file with the configuration specified by the various `:bundler_*` tomo settings. This ensures that invocations of `bundle check`, `bundle install`, and most importantly `bundle exec` all consistently use the correct bundler configuration.
+
+`bundler:config` is intended for use as a [setup](../commands/setup.md) task. It should be run prior to [bundler:install](#bundlerinstall) so that gems are installed in the proper location.
 
 ### bundler:install
 

--- a/docs/plugins/bundler.md
+++ b/docs/plugins/bundler.md
@@ -15,7 +15,6 @@ Note that the settings listed here only take effect if you run the [bundler:conf
 | `bundler_path`        | Directory where gems where be installed                                                                                                                                       | `"%<shared_path>/bundle"` |
 | `bundler_retry`       | Number of times to retry installing a gem if it fails to download                                                                                                             | `"3"`                     |
 | `bundler_version`     | The version of bundler to install, used by the [bundler:upgrade_bundler](#bundlerupgrade_bundler) task; if `nil` (the default), determine the version based on `Gemfile.lock` | `nil`                     |
-| `bundler_with`        | Array of Gemfile groups to install (empty implies all groups)                                                                                                                 | `[]`                      |
 | `bundler_without`     | Array of Gemfile groups to exclude from installation                                                                                                                          | `["development", "test"]` |
 
 ## Tasks

--- a/lib/tomo/plugin/bundler.rb
+++ b/lib/tomo/plugin/bundler.rb
@@ -8,11 +8,14 @@ module Tomo::Plugin
     tasks Tomo::Plugin::Bundler::Tasks
     helpers Tomo::Plugin::Bundler::Helpers
 
-    defaults bundler_install_flags: ["--deployment"],
-             bundler_gemfile:       nil,
-             bundler_jobs:          "4",
-             bundler_path:          "%<shared_path>/bundle",
-             bundler_version:       nil,
-             bundler_without:       %w[development test]
+    defaults bundler_config_path: ".bundle/config",
+             bundler_deployment:  true,
+             bundler_gemfile:     nil,
+             bundler_jobs:        "4",
+             bundler_path:        "%<shared_path>/bundle",
+             bundler_retry:       "3",
+             bundler_version:     nil,
+             bundler_with:        [],
+             bundler_without:     %w[development test]
   end
 end

--- a/lib/tomo/plugin/bundler.rb
+++ b/lib/tomo/plugin/bundler.rb
@@ -15,7 +15,6 @@ module Tomo::Plugin
              bundler_path:        "%<shared_path>/bundle",
              bundler_retry:       "3",
              bundler_version:     nil,
-             bundler_with:        [],
              bundler_without:     %w[development test]
   end
 end

--- a/lib/tomo/plugin/bundler/tasks.rb
+++ b/lib/tomo/plugin/bundler/tasks.rb
@@ -1,9 +1,28 @@
+require "yaml"
+
 module Tomo::Plugin::Bundler
   class Tasks < Tomo::TaskLibrary
-    def install
-      return if remote.bundle?("check", *check_options) && !dry_run?
+    CONFIG_SETTINGS = %i[
+      bundler_deployment
+      bundler_gemfile
+      bundler_jobs
+      bundler_path
+      bundler_retry
+      bundler_with
+      bundler_without
+    ].freeze
+    private_constant :CONFIG_SETTINGS
 
-      remote.bundle("install", *install_options)
+    def config
+      configuration = settings_to_configuration
+      remote.mkdir_p paths.bundler_config.dirname
+      remote.write(text: YAML.dump(configuration), to: paths.bundler_config)
+    end
+
+    def install
+      return if remote.bundle?("check") && !dry_run?
+
+      remote.bundle("install")
     end
 
     def clean
@@ -23,31 +42,19 @@ module Tomo::Plugin::Bundler
 
     private
 
+    def settings_to_configuration
+      CONFIG_SETTINGS.each_with_object({}) do |key, config|
+        next if settings[key].nil?
+
+        entry_key = "BUNDLE_#{key.to_s.sub(/^bundler_/, '').upcase}"
+        entry_value = settings.fetch(key)
+        entry_value = entry_value.join(":") if entry_value.is_a?(Array)
+        config[entry_key] = entry_value.to_s
+      end
+    end
+
     def version_setting
       settings[:bundler_version]
-    end
-
-    def check_options
-      gemfile = settings[:bundler_gemfile]
-      path = paths.bundler
-
-      options = []
-      options.push("--gemfile", gemfile) if gemfile
-      options.push("--path", path) if path
-      options
-    end
-
-    def install_options
-      jobs = settings[:bundler_jobs]
-      without = settings[:bundler_without]
-      flags = settings[:bundler_install_flags]
-
-      options = check_options.dup
-      options.push("--jobs", jobs) if jobs
-      options.push("--without", without) if without
-      options.push(flags) if flags
-
-      options.flatten
     end
 
     def extract_bundler_ver_from_lockfile

--- a/lib/tomo/plugin/bundler/tasks.rb
+++ b/lib/tomo/plugin/bundler/tasks.rb
@@ -8,7 +8,6 @@ module Tomo::Plugin::Bundler
       bundler_jobs
       bundler_path
       bundler_retry
-      bundler_with
       bundler_without
     ].freeze
     private_constant :CONFIG_SETTINGS

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -29,7 +29,6 @@ set env_vars: {
   SECRET_KEY_BASE: :prompt
 }
 set linked_dirs: %w[
-  .bundle
   log
   node_modules
   public/assets
@@ -47,6 +46,7 @@ setup do
   run "nodenv:install"
   run "rbenv:install"
   run "bundler:upgrade_bundler"
+  run "bundler:config"
   run "bundler:install"
   run "rails:db_create"
   run "rails:db_schema_load"

--- a/test/tomo/plugin/bundler/tasks_test.rb
+++ b/test/tomo/plugin/bundler/tasks_test.rb
@@ -2,6 +2,67 @@ require "test_helper"
 require "tomo/plugin/bundler"
 
 class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
+  def test_install
+    tester = configure(release_path: "/app/release")
+    tester.mock_script_result(/bundle check/, exit_status: 1)
+    tester.run_task("bundler:install")
+    assert_equal(
+      [
+        "cd /app/release && bundle check",
+        "cd /app/release && bundle install"
+      ],
+      tester.executed_scripts
+    )
+  end
+
+  def test_config_writes_local_config_file
+    tester = configure(
+      bundler_config_path: ".bundle/config",
+      bundler_deployment: true,
+      bundler_gemfile: "Gemfile.prod",
+      bundler_jobs: 12,
+      bundler_path: "/app/bundle",
+      bundler_retry: 2,
+      bundler_with: %w[production],
+      bundler_without: %w[development test staging],
+      release_path: "/app/release"
+    )
+    tester.run_task("bundler:config")
+    assert_equal("mkdir -p .bundle", tester.executed_scripts.first)
+    assert_equal(<<~'SCRIPT'.strip, tester.executed_scripts.last)
+      echo -n ---'
+      'BUNDLE_DEPLOYMENT:\ \'true\''
+      'BUNDLE_GEMFILE:\ Gemfile.prod'
+      'BUNDLE_JOBS:\ \'12\''
+      'BUNDLE_PATH:\ \"/app/bundle\"'
+      'BUNDLE_RETRY:\ \'2\''
+      'BUNDLE_WITH:\ production'
+      'BUNDLE_WITHOUT:\ development:test:staging'
+      ' > .bundle/config
+    SCRIPT
+  end
+
+  def test_config_excludes_nil_settings_from_config_file
+    tester = configure(
+      bundler_config_path: ".bundle/config",
+      bundler_deployment: false,
+      bundler_gemfile: nil,
+      bundler_jobs: nil,
+      bundler_path: "/app/bundle",
+      bundler_retry: nil,
+      bundler_with: nil,
+      bundler_without: nil,
+      release_path: "/app/release"
+    )
+    tester.run_task("bundler:config")
+    assert_equal(<<~'SCRIPT'.strip, tester.executed_scripts.last)
+      echo -n ---'
+      'BUNDLE_DEPLOYMENT:\ \'false\''
+      'BUNDLE_PATH:\ \"/app/bundle\"'
+      ' > .bundle/config
+    SCRIPT
+  end
+
   def test_upgrade_bundler_uses_lock_file_for_version
     tester = configure
     tester.mock_script_result(/^tail .*Gemfile\.lock/, stdout: <<~OUT)

--- a/test/tomo/plugin/bundler/tasks_test.rb
+++ b/test/tomo/plugin/bundler/tasks_test.rb
@@ -23,7 +23,6 @@ class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
       bundler_jobs: 12,
       bundler_path: "/app/bundle",
       bundler_retry: 2,
-      bundler_with: %w[production],
       bundler_without: %w[development test staging],
       release_path: "/app/release"
     )
@@ -36,7 +35,6 @@ class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
       'BUNDLE_JOBS:\ \'12\''
       'BUNDLE_PATH:\ \"/app/bundle\"'
       'BUNDLE_RETRY:\ \'2\''
-      'BUNDLE_WITH:\ production'
       'BUNDLE_WITHOUT:\ development:test:staging'
       ' > .bundle/config
     SCRIPT
@@ -50,7 +48,6 @@ class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
       bundler_jobs: nil,
       bundler_path: "/app/bundle",
       bundler_retry: nil,
-      bundler_with: nil,
       bundler_without: nil,
       release_path: "/app/release"
     )


### PR DESCRIPTION
Starting with bundler 2.1, flags like `--path` are deprecated for the `bundle check` and `bundle install` commands. [In bundler 3.0 these flags will be dropped altogether.](https://github.com/bundler/bundler/blob/v2.1.0.pre.1/UPGRADING.md#cli-deprecations) That means the preferred way to configure the behavior of bundler going forward is to use either environment variables or a `.bundle/config` file.

This commit changes how tomo uses bundler to be forward-compatible with bundler 3.0.  Now, instead of passing flags to `bundle install`, tomo has a new task called `bundler:config` that will write an appropriate `.bundle/config` file based on the various `:bundler_*` tomo settings.

This is a breaking change due to the following:

1. The general-purpose `:bundler_install_flags` setting has been    removed. To configure bundler use one of the more specific settings    instead.
2. The `.bundle` directory has been removed from `:linked_dirs`. This is because tomo no longer relies on the side effects of `bundle install` to create the contents of this directory. Instead, tomo now manages its own `.bundle` directory (global by default).
3. To configure bundler properly you must add the new `bundler:config` task to `setup` just before `bundler:install`.

This commit also adds support for the `retry` option.