### PR TITLE
Add :git_ref setting to allow deploying an arbitrary SHA/tag

### DIFF
--- a/docs/plugins/git.md
+++ b/docs/plugins/git.md
@@ -10,6 +10,7 @@ The git plugin uses git running on the remote host to fetch the code of the app 
 | `git_repo_path`  | Directory on the remote host where a cache of the repository will be stored                                                                                                                                           | `"%<deploy_to>/git_repo"`                                                             |
 | `git_exclusions` | An array of paths (similar to gitignore syntax) that will be excluded when the repository is copied into a release; it is recommend you exclude `.tomo/` and other directories not needed in production, like `spec/` | `[]`                                                                                  |
 | `git_env`        | Environment variables that will be set when issuing git commands (hash)                                                                                                                                               | `{ GIT_SSH_COMMAND: "ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no" }` |
+| `git_ref`        | The commit SHA or tag to deploy (overrides `:git_branch`)                                                                                                                                                             | `nil`                                                                                 |
 | `git_url`        | URL of the git repository; always use the SSH form like `git@github.com:username/repo.git` (not HTTPS)                                                                                                                | `nil`                                                                                 |
 
 ## Tasks
@@ -22,7 +23,7 @@ Performs the initial clone of the git repository. This is necessary before a dep
 
 ### git:create_release
 
-Fetches the latest commits from `git_branch` and creates a release by copying the contents of that branch of repository into a new release inside the `releases_path`. Releases are numbered based on the timestamp of when the deploy takes place.
+Fetches the latest commits from `git_branch` (or `git_ref`) and creates a release by copying the contents of that branch of repository into a new release inside the `releases_path`. Releases are numbered based on the timestamp of when the deploy takes place.
 
 `git:create_release` is intended for use as a [deploy](../commands/deploy.md) task.
 

--- a/lib/tomo/plugin/core/tasks.rb
+++ b/lib/tomo/plugin/core/tasks.rb
@@ -60,9 +60,12 @@ module Tomo::Plugin::Core
 
     # rubocop:disable Metrics/AbcSize
     def log_revision
+      ref = remote.release[:ref]
+      revision = remote.release[:revision]
+
       message = remote.release[:deploy_date].to_s
-      message << " - #{remote.release[:revision] || '<unknown>'}"
-      message << " (#{remote.release[:branch] || '<unknown>'})"
+      message << " - #{revision || '<unknown>'}"
+      message << " (#{ref})" if ref && revision && !revision.start_with?(ref)
       message << " deployed by #{remote.release[:deploy_user] || '<unknown>'}"
       message << "\n"
 

--- a/lib/tomo/plugin/git.rb
+++ b/lib/tomo/plugin/git.rb
@@ -13,6 +13,7 @@ module Tomo::Plugin
              git_repo_path:  "%<deploy_to>/git_repo",
              git_exclusions: [],
              git_env:        { GIT_SSH_COMMAND: "ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no" },
+             git_ref:        nil,
              git_url:        nil
     # rubocop:enable Metrics/LineLength
   end

--- a/lib/tomo/plugin/git/tasks.rb
+++ b/lib/tomo/plugin/git/tasks.rb
@@ -14,8 +14,8 @@ module Tomo::Plugin::Git
         remote.git("clone", "--mirror", settings[:git_url], paths.git_repo)
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
+    # rubocop:disable Metrics/MethodLength
     def create_release
       remote.chdir(paths.git_repo) do
         remote.git("remote update --prune")
@@ -32,6 +32,8 @@ module Tomo::Plugin::Git
         )
       end
     end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/lib/tomo/plugin/git/tasks.rb
+++ b/lib/tomo/plugin/git/tasks.rb
@@ -14,20 +14,24 @@ module Tomo::Plugin::Git
         remote.git("clone", "--mirror", settings[:git_url], paths.git_repo)
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def create_release
-      configure_git_attributes
       remote.chdir(paths.git_repo) do
         remote.git("remote update --prune")
-        remote.mkdir_p(paths.release)
+      end
+
+      store_release_info
+      configure_git_attributes
+      remote.mkdir_p(paths.release)
+
+      remote.chdir(paths.git_repo) do
         remote.git(
           "archive #{ref.shellescape} | "\
           "tar -x -f - -C #{paths.release.shellescape}"
         )
       end
-      store_release_info
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 
@@ -72,7 +76,7 @@ module Tomo::Plugin::Git
       log = remote.chdir(paths.git_repo) do
         remote.git(
           'log -n1 --date=iso --pretty=format:"%H/%cd/%ae" '\
-          "#{ref.shellescape}",
+          "#{ref.shellescape} --",
           silent: true
         ).stdout.strip
       end

--- a/test/tomo/plugin/core/tasks_test.rb
+++ b/test/tomo/plugin/core/tasks_test.rb
@@ -150,7 +150,7 @@ class Tomo::Plugin::Core::TasksTest < Minitest::Test
         revision_log_path: "/app/revision.log"
       },
       release: {
-        branch: "master",
+        ref: "master",
         deploy_date: now,
         deploy_user: "matt",
         revision: "65eda21"

--- a/test/tomo/plugin/git/tasks_test.rb
+++ b/test/tomo/plugin/git/tasks_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+require "tomo/plugin/git"
+
+class Tomo::Plugin::Git::TasksTest < Minitest::Test
+  def test_create_release_uses_branch_if_specified
+    tester = configure(git_branch: "develop")
+    tester.run_task("git:create_release")
+    assert_equal(
+      "cd /repo && git archive develop | tar -x -f - -C /app",
+      tester.executed_scripts.grep(/git archive/).first
+    )
+  end
+
+  def test_create_release_uses_ref_if_specified
+    tester = configure(git_branch: nil, git_ref: "a944898")
+    tester.run_task("git:create_release")
+    assert_equal(
+      "cd /repo && git archive a944898 | tar -x -f - -C /app",
+      tester.executed_scripts.grep(/git archive/).first
+    )
+  end
+
+  def test_create_release_uses_ref_if_both_branch_and_ref_specified
+    tester = configure(git_branch: "master", git_ref: "a944898")
+    tester.run_task("git:create_release")
+    assert_equal(
+      "cd /repo && git archive a944898 | tar -x -f - -C /app",
+      tester.executed_scripts.grep(/git archive/).first
+    )
+    assert_equal(<<~ERROR, tester.stderr)
+      WARNING: :git_ref (a944898) and :git_branch (master) are both specified. Ignoring :git_branch.
+    ERROR
+  end
+
+  def test_create_release_raises_error_if_branch_and_ref_both_nil
+    tester = configure(git_branch: nil, git_ref: nil)
+    assert_raises(Tomo::Runtime::SettingsRequiredError) do
+      tester.run_task("git:create_release")
+    end
+  end
+
+  private
+
+  def configure(settings={})
+    defaults = {
+      git_env: {},
+      git_repo_path: "/repo",
+      release_path: "/app"
+    }
+    settings = defaults.merge(settings)
+    Tomo::Testing::MockPluginTester.new("git", settings: settings)
+  end
+end


### PR DESCRIPTION
In a CI situation, you will want to deploy the commit that was just tested by CI, rather than a branch name which may point to a different commit.

For example consider the situation where a developer pushes commit A to master and the CI build starts. A few seconds later another developer pushes commit B to master. The CI build for commit A is successful and triggers a deploy via tomo. However since tomo deploys whatever is on master, that means commit B will actually get deployed, even though it hasn't been tested yet by CI.

This PR adds a new setting called `:git_ref` that can be used to tell tomo to deploy a specific commit, like this:

```
$ tomo deploy -s git_ref=a944898
```

If `:git_ref` is specified it overrides the `:git_branch` setting.

Note that `:git_ref` and `:git_branch` actually both work the same way (you could actually pass a SHA to `:git_branch` and it would still work), but the `:git_ref` name makes the intention more clear. Most beginners to tomo will likely find `:git_branch` more intuitive (the CI scenario described above is fairly advanced) so I am keeping it around as the default.

This PR also moves `git log` earlier in the `create_release` task to improve error messaging. Before, if an invalid branch or ref is specified, the user would get the cryptic error "tar: This does not look like a tar archive". Now they get a more appropriate "fatal: bad revision".