### PR TITLE
Add support for ERB templates

### DIFF
--- a/docs/api/TaskLibrary.md
+++ b/docs/api/TaskLibrary.md
@@ -71,6 +71,39 @@ Like `require_setting`, except it accepts an arbitrary number of setting names. 
 require_settings :puma_control_token, :puma_control_url
 ```
 
+### merge_template(path) → String
+
+Given a local `path` to an [ERB](https://ruby-doc.org/stdlib/libdoc/erb/rdoc/ERB.html) template, merge that template and return the resulting string. The ERB template can access the same API that tasks and helpers can access, namely: `settings`, `paths`, `remote`, and `raw`.
+
+Here is an example of an ERB template:
+
+```erb
+Hello, <%= settings[:application] %>!
+```
+
+If `path` begins with a `"."` it is interpreted as a path relative to the tomo configuration file. This allows for easy reference to project-specific templates. For example, given this directory structure:
+
+```plain
+.tomo
+├── config.rb
+└── templates
+    └── unicorn.service.erb
+```
+
+Then you could reference the template in a setting like this:
+
+```ruby
+# .tomo/config.rb
+
+set unicorn_service_template_path: "./templates/unicorn.service.erb"
+```
+
+And merge it in a task:
+
+```ruby
+merge_template(paths.unicorn_service_template)
+```
+
 ### dry_run? → true or false
 
 Returns `true` if tomo was started with the `--dry-run` option. This is useful if there are certain code paths you want to ensure are taken during a dry run.

--- a/docs/plugins/core.md
+++ b/docs/plugins/core.md
@@ -112,14 +112,21 @@ Run the given command, returning `true` if the command succeeded (exit status of
 remote.run?("which", "java") # => false
 ```
 
-### remote.write(text:, to:, append: false, \*\*options) → [Tomo::Result](../api/Result.md)
+### remote.write(text:/template:, to:, append: false, \*\*options) → [Tomo::Result](../api/Result.md)
 
-Write the given `text` (must be a String) to the remote path specified by `to:`. If `append` is `false` (the default), the remote file will completely replaced; if `true`, the file will be appended to. This is designed for small amounts of text (e.g. configuration files), not large or binary data.
+Write the given `text` (a String) or the text resulting from merging the given `template` (a local path to an ERB template file) to the remote path specified by `to:`. Refer to the [merge_template](../api/TaskLibrary.md#merge_templatepath-string) documentation for details on tomo’s ERB templating behavior.
+
+If `append` is `false` (the default), the remote file will completely replaced; if `true`, the file will be appended to. This is designed for small amounts of text (e.g. configuration files), not large or binary data.
 
 ```ruby
 remote.write text: "hello world!\n",
              to: paths.shared.join("greetings.txt"),
              append: true
+```
+
+```ruby
+remote.write template: File.expand_path("unicorn.service.erb", __dir__),
+             to: ".config/systemd/user/unicorn.service"
 ```
 
 ### remote.ln_sf(target, link, \*\*options) → [Tomo::Result](../api/Result.md)

--- a/docs/plugins/core.md
+++ b/docs/plugins/core.md
@@ -26,6 +26,7 @@ The core plugin provides tasks, settings, and helpers that are the fundamental b
 | `ssh_reuse_connections`        | Whether to use `ControlMaster` to keep connections open across multiple invocations of ssh; setting this to `false` will slow down tomo significantly                                                     | `true`                                 |
 | `ssh_strict_host_key_checking` | Use `"accept-new"` for a good compromise of security and convenience, `true` for most security, `false` for most convenience; note that older versions of ssh do not understand the `"accept-new"` option | `"accept-new"`                         |
 | `tmp_path`                     | Directory where the [setup](../commands/setup.md) command stages temporary files                                                                                                                          | `"/tmp/tomo"`                          |
+| `tomo_config_file_path`        | A special read-only setting containing the path to the `config.rb` file that was used to configure tomo                                                                                                   | `"/path/to/.tomo/config.rb"`           |
 
 ## Tasks
 

--- a/docs/tutorials/writing-custom-tasks.md
+++ b/docs/tutorials/writing-custom-tasks.md
@@ -16,23 +16,15 @@ plugin "./plugins/cron.rb"
 
 ```ruby
 # .tomo/plugins/cron.rb
-require "erb"
-
 def show
   remote.run "crontab -l", raise_on_error: false
 end
 
 def install
-  crontab = merge_template("../templates/crontab.erb")
+  template_path = File.expand_path("../templates/crontab.erb", __dir__)
+  crontab = merge_template(template_path)
   remote.run "echo #{crontab.shellescape} | crontab -",
              echo: "echo [template:.tomo/templates/crontab.erb] | crontab -"
-end
-
-private
-
-def merge_template(path)
-  template = IO.read(File.expand_path(path, __dir__))
-  ERB.new(template).result(binding)
 end
 ```
 
@@ -142,7 +134,7 @@ We'll start by building the simpler of the two tasks: `cron:show`. First, let's 
 
 ```plain
 $ tomo run cron:show
-tomo run v0.3.0
+tomo run v0.7.0
 
   ERROR: cron:show is not a recognized task.
   To see a list of all available tasks, run tomo tasks.
@@ -170,7 +162,7 @@ Now we can try again:
 
 ```plain
 $ tomo run cron:show
-tomo run v0.3.0
+tomo run v0.7.0
 → Connecting to deployer@app.example.com
 • cron:show
 Hi
@@ -189,7 +181,7 @@ One more try:
 
 ```plain
 $ tomo run cron:show
-tomo run v0.3.0
+tomo run v0.7.0
 → Connecting to deployer@app.example.com
 • cron:show
 crontab -l
@@ -220,7 +212,7 @@ Now we're all good:
 
 ```plain
 $ tomo run cron:show
-tomo run v0.3.0
+tomo run v0.7.0
 → Connecting to deployer@app.example.com
 • cron:show
 crontab -l
@@ -245,7 +237,7 @@ If we try to run `tomo setup` at this point, we'll get an error as expected:
 
 ```plain
 $ tomo setup
-tomo setup v0.3.0
+tomo setup v0.7.0
 
   ERROR: cron:install is not a recognized task.
   To see a list of all available tasks, run tomo tasks.
@@ -271,7 +263,7 @@ We can see what this task does without actually affecting the remote host by usi
 
 ```plain
 $ tomo run cron:install --dry-run
-tomo run v0.3.0
+tomo run v0.7.0
 * → Connecting to deployer@app.example.com
 * • cron:install
 * echo SHELL\=/bin/bash'
@@ -280,43 +272,21 @@ tomo run v0.3.0
 * Simulated cron:install on deployer@app.example.com (dry run)
 ```
 
-Looks good! But we if we made it more powerful with some erb templating?
+Looks good! But we if we made it more powerful with some ERB templating?
 
 ### Templates
 
-There are no built-in templating mechanisms in tomo, but that's because tomo tasks are just Ruby, and we can implement a template with erb templates in just a few lines of code.
-
-First we can add a _private_ method to our `.tomo/plugins/cron.rb` file. Private methods are not exposed as tomo tasks but give us the ability to organize our code. This private method reads in an erb template, evaluates it, and returns the rendered template as a string:
-
-```ruby
-require "erb"
-
-def show
-  # ...
-end
-
-def install
-  # ...
-end
-
-private
-
-def merge_template(path)
-  template = IO.read(File.expand_path(path, __dir__))
-  ERB.new(template).result(binding)
-end
-```
-
-Now we can use a template instead of a hard-coded cron job:
+Tomo offers a convenient way to use ERB templates with it’s built-in [merge_template](../api/TaskLibrary.md#merge_templatepath-string) and [write](../plugins/core.md#remotewritetexttemplate-to-append-false-4242options-tomoresult) methods. We can use `merge_template` instead of a hard-coding the cron job:
 
 ```ruby
 def install
-  crontab = merge_template("../templates/crontab.erb")
+  template_path = File.expand_path("../templates/crontab.erb", __dir__)
+  crontab = merge_template(template_path)
   remote.run "echo #{crontab.shellescape} | crontab -"
 end
 ```
 
-The erb template has access to all the same APIs as our task methods; that means we can remove the hard-coded paths from our original cron job specification and use tomo's `paths` helper. So our erb template file (`.tomo/templates/crontab.erb`) could look like this:
+The ERB template has access to all the same APIs as our task methods; that means we can remove the hard-coded paths from our original cron job specification and use tomo's `paths` helper. So our ERB template file (`.tomo/templates/crontab.erb`) could look like this:
 
 ```sh
 # ./templates/crontab.erb
@@ -328,7 +298,7 @@ Let's check that it still works:
 
 ```plain
 $ tomo run cron:install --dry-run
-tomo run v0.3.0
+tomo run v0.7.0
 * → Connecting to deployer@app.example.com
 * • cron:install
 * echo SHELL\=/bin/bash'
@@ -341,7 +311,8 @@ That's great, but the output is really verbose. Do we really need to see the ful
 
 ```ruby
 def install
-  crontab = merge_template("../templates/crontab.erb")
+  template_path = File.expand_path("../templates/crontab.erb", __dir__)
+  crontab = merge_template(template_path)
   remote.run "echo #{crontab.shellescape} | crontab -",
              echo: "echo [template:.tomo/templates/crontab.erb] | crontab -"
 end
@@ -351,7 +322,7 @@ And then try it:
 
 ```plain
 $ tomo run cron:install --dry-run
-tomo run v0.3.0
+tomo run v0.7.0
 * → Connecting to deployer@app.example.com
 * • cron:install
 * echo [template:.tomo/templates/crontab.erb] | crontab -
@@ -376,7 +347,7 @@ And we can see what is installed with our `cron:show` task:
 
 ```plain
 $ tomo run cron:show
-tomo run v0.3.0
+tomo run v0.7.0
 → Connecting to deployer@app.example.com
 • cron:show
 crontab -l

--- a/lib/tomo.rb
+++ b/lib/tomo.rb
@@ -17,6 +17,7 @@ module Tomo
   autoload :Script, "tomo/script"
   autoload :ShellBuilder, "tomo/shell_builder"
   autoload :SSH, "tomo/ssh"
+  autoload :TaskAPI, "tomo/task_api"
   autoload :TaskLibrary, "tomo/task_library"
   autoload :VERSION, "tomo/version"
 

--- a/lib/tomo/plugin/core.rb
+++ b/lib/tomo/plugin/core.rb
@@ -9,20 +9,21 @@ module Tomo::Plugin
     tasks Tomo::Plugin::Core::Tasks
 
     defaults Tomo::SSH::Options::DEFAULTS.merge(
-      application:       "default",
-      concurrency:       10,
-      current_path:      "%<deploy_to>/current",
-      deploy_to:         "/var/www/%<application>",
-      keep_releases:     10,
-      linked_dirs:       [],
-      linked_files:      [],
-      local_user:        nil, # determined at runtime
-      release_json_path: "%<release_path>/.tomo_release.json",
-      releases_path:     "%<deploy_to>/releases",
-      revision_log_path: "%<deploy_to>/revisions.log",
-      shared_path:       "%<deploy_to>/shared",
-      tmp_path:          "/tmp/tomo",
-      run_args:          [] # determined at runtime
+      application:           "default",
+      concurrency:           10,
+      current_path:          "%<deploy_to>/current",
+      deploy_to:             "/var/www/%<application>",
+      keep_releases:         10,
+      linked_dirs:           [],
+      linked_files:          [],
+      local_user:            nil, # determined at runtime
+      release_json_path:     "%<release_path>/.tomo_release.json",
+      releases_path:         "%<deploy_to>/releases",
+      revision_log_path:     "%<deploy_to>/revisions.log",
+      shared_path:           "%<deploy_to>/shared",
+      tmp_path:              "/tmp/tomo",
+      tomo_config_file_path: nil, # determined at runtime
+      run_args:              [] # determined at runtime
     )
   end
 end

--- a/lib/tomo/plugin/core/helpers.rb
+++ b/lib/tomo/plugin/core/helpers.rb
@@ -12,7 +12,9 @@ module Tomo::Plugin::Core
       result.success?
     end
 
-    def write(text:, to:, append: false, **run_opts)
+    def write(text: nil, template: nil, to:, append: false, **run_opts)
+      assert_text_or_template_required!(text, template)
+      text = merge_template(template) unless template.nil?
       message = "Writing #{text.bytesize} bytes to #{to}"
       run(
         "echo -n #{text.shellescape} #{append ? '>>' : '>'} #{to.shellescape}",
@@ -60,6 +62,12 @@ module Tomo::Plugin::Core
 
     def flag?(flag, path, **run_opts)
       run?("[ #{flag} #{path.to_s.shellescape} ]", **run_opts)
+    end
+
+    def assert_text_or_template_required!(text, template)
+      return if text.nil? ^ template.nil?
+
+      raise ArgumentError, "specify text: or template:"
     end
   end
 end

--- a/lib/tomo/remote.rb
+++ b/lib/tomo/remote.rb
@@ -2,6 +2,8 @@ require "forwardable"
 
 module Tomo
   class Remote
+    include TaskAPI
+
     extend Forwardable
     def_delegators :ssh, :close, :host
     def_delegators :shell_builder, :chdir, :env, :prepend, :umask
@@ -33,20 +35,7 @@ module Tomo
 
     private
 
-    def_delegators :context, :paths, :settings
     attr_reader :context, :ssh, :shell_builder
-
-    def dry_run?
-      Tomo.dry_run?
-    end
-
-    def logger
-      Tomo.logger
-    end
-
-    def raw(str)
-      ShellBuilder.raw(str)
-    end
 
     def remote
       self

--- a/lib/tomo/runtime.rb
+++ b/lib/tomo/runtime.rb
@@ -16,6 +16,7 @@ module Tomo
     autoload :SettingsRequiredError, "tomo/runtime/settings_required_error"
     autoload :TaskAbortedError, "tomo/runtime/task_aborted_error"
     autoload :TaskRunner, "tomo/runtime/task_runner"
+    autoload :TemplateNotFoundError, "tomo/runtime/template_not_found_error"
     autoload :UnknownTaskError, "tomo/runtime/unknown_task_error"
 
     def self.local_user

--- a/lib/tomo/runtime/template_not_found_error.rb
+++ b/lib/tomo/runtime/template_not_found_error.rb
@@ -1,0 +1,11 @@
+module Tomo
+  class Runtime
+    class TemplateNotFoundError < Error
+      attr_accessor :path
+
+      def to_console
+        "Template not found: #{yellow(path)}"
+      end
+    end
+  end
+end

--- a/lib/tomo/task_api.rb
+++ b/lib/tomo/task_api.rb
@@ -30,6 +30,9 @@ module Tomo
         path = File.expand_path(path, working_path)
       end
 
+      unless File.file?(path)
+        Runtime::TemplateNotFoundError.raise_with(path: path)
+      end
       template = IO.read(path)
       ERB.new(template).result(binding)
     end

--- a/lib/tomo/task_api.rb
+++ b/lib/tomo/task_api.rb
@@ -1,0 +1,44 @@
+module Tomo
+  module TaskAPI
+    extend Forwardable
+
+    private
+
+    def_delegators :context, :paths, :settings
+
+    def die(reason)
+      Runtime::TaskAbortedError.raise_with(
+        reason,
+        task: context.current_task,
+        host: remote.host
+      )
+    end
+
+    def dry_run?
+      Tomo.dry_run?
+    end
+
+    def logger
+      Tomo.logger
+    end
+
+    def raw(string)
+      ShellBuilder.raw(string)
+    end
+
+    def remote
+      context.current_remote
+    end
+
+    def require_setting(*names)
+      missing = names.flatten.select { |sett| settings[sett].nil? }
+      return if missing.empty?
+
+      Runtime::SettingsRequiredError.raise_with(
+        settings: missing,
+        task: context.current_task
+      )
+    end
+    alias require_settings require_setting
+  end
+end

--- a/lib/tomo/task_api.rb
+++ b/lib/tomo/task_api.rb
@@ -1,3 +1,5 @@
+require "erb"
+
 module Tomo
   module TaskAPI
     extend Forwardable
@@ -20,6 +22,16 @@ module Tomo
 
     def logger
       Tomo.logger
+    end
+
+    def merge_template(path)
+      working_path = paths.tomo_config_file&.dirname
+      if working_path && path.start_with?(".")
+        path = File.expand_path(path, working_path)
+      end
+
+      template = IO.read(path)
+      ERB.new(template).result(binding)
     end
 
     def raw(string)

--- a/lib/tomo/task_library.rb
+++ b/lib/tomo/task_library.rb
@@ -2,7 +2,7 @@ require "forwardable"
 
 module Tomo
   class TaskLibrary
-    extend Forwardable
+    include TaskAPI
 
     def initialize(context)
       @context = context
@@ -10,42 +10,6 @@ module Tomo
 
     private
 
-    def_delegators :context, :paths, :settings
     attr_reader :context
-
-    def die(reason)
-      Runtime::TaskAbortedError.raise_with(
-        reason,
-        task: context.current_task,
-        host: remote.host
-      )
-    end
-
-    def dry_run?
-      Tomo.dry_run?
-    end
-
-    def logger
-      Tomo.logger
-    end
-
-    def raw(string)
-      ShellBuilder.raw(string)
-    end
-
-    def remote
-      context.current_remote
-    end
-
-    def require_setting(*names)
-      missing = names.flatten.select { |sett| settings[sett].nil? }
-      return if missing.empty?
-
-      Runtime::SettingsRequiredError.raise_with(
-        settings: missing,
-        task: context.current_task
-      )
-    end
-    alias require_settings require_setting
   end
 end

--- a/test/fixtures/template.erb
+++ b/test/fixtures/template.erb
@@ -1,0 +1,1 @@
+Hello, <%= settings[:application] %>!

--- a/test/tomo/task_api_test.rb
+++ b/test/tomo/task_api_test.rb
@@ -24,7 +24,7 @@ class Tomo::TaskAPITest < Minitest::Test
 
   def test_merge_template_raises_on_file_not_found
     subject = configure
-    assert_raises(Errno::ENOENT) do
+    assert_raises(Tomo::Runtime::TemplateNotFoundError) do
       subject.send(:merge_template, "path_does_not_exist")
     end
   end

--- a/test/tomo/task_api_test.rb
+++ b/test/tomo/task_api_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Tomo::TaskAPITest < Minitest::Test
+  Subject = Struct.new(:context)
+  Subject.include Tomo::TaskAPI
+
+  def test_merge_template_with_absolute_path
+    abs_path = File.expand_path("../fixtures/template.erb", __dir__)
+    subject = configure(application: "test-app")
+    merged = subject.send(:merge_template, abs_path)
+    assert_equal("Hello, test-app!\n", merged)
+  end
+
+  def test_merge_template_with_path_relative_to_config
+    config_path = File.expand_path("../../.tomo/config.rb", __dir__)
+    rel_path = "../test/fixtures/template.erb"
+    subject = configure(
+      application: "test-app",
+      tomo_config_file_path: config_path
+    )
+    merged = subject.send(:merge_template, rel_path)
+    assert_equal("Hello, test-app!\n", merged)
+  end
+
+  def test_merge_template_raises_on_file_not_found
+    subject = configure
+    assert_raises(Errno::ENOENT) do
+      subject.send(:merge_template, "path_does_not_exist")
+    end
+  end
+
+  private
+
+  def configure(settings={})
+    defaults = { tomo_config_file_path: nil }
+    Subject.new(Tomo::Runtime::Context.new(defaults.merge(settings)))
+  end
+end


### PR DESCRIPTION
The PR enhances the `write` helper such that it now optionally accepts a `template:` keyword argument instead of `text:`. If `template:` is specified, merge the given template (a local path to an ERB template file) and write the resulting text to the remote location.

For example:

```ruby
remote.write template: File.expand_path("unicorn.service.erb", __dir__),
             to: ".config/systemd/user/unicorn.service"
```

For tasks that wish to deal with templates directly, this PR also introduces a `merge_template` method that loads an ERB template from a specified path and merges it.

Both `write template:` and `merge_template` follow this behavior:

- If the template path starts with a `"."`, treat it as relative to the tomo config directory
- The ERB template can access `settings`, `paths`, `remote`, etc.

This PR also contains the following enhancements and refactors:

- Refactor common methods into a `TaskAPI` module: Developers expect a consistent API writing tasks and helpers. Before, this consistency was implemented through copy-and-paste. Now it is better enforced via a `TaskAPI` module that is included in both `Remote` and `TaskLibrary`.
- Add `:tomo_config_file_path` setting, which is automatically set based on where the configuration is loaded from.
- Update custom task tutorial to use the new `merge_template` method
