### PR TITLE
Remove support for deprecated %<...> syntax

### DIFF
--- a/lib/tomo/runtime/settings_interpolation.rb
+++ b/lib/tomo/runtime/settings_interpolation.rb
@@ -7,74 +7,32 @@ module Tomo
 
       def initialize(settings)
         @settings = symbolize(settings)
-        @deprecation_warnings = []
       end
 
       def call
         hash = Hash[settings.keys.map { |name| [name, fetch(name)] }]
         dump_settings(hash) if Tomo.debug?
-        print_deprecation_warnings
         hash
       end
 
       private
 
-      attr_reader :settings, :deprecation_warnings
+      attr_reader :settings
 
-      # rubocop:disable Metrics/AbcSize
       def fetch(name, stack=[])
         raise_circular_dependency_error(name, stack) if stack.include?(name)
         value = settings.fetch(name)
         return value unless value.is_a?(String)
 
-        value.gsub(/%{(\w+)}|%<(\w+)>/) do
-          token = Regexp.last_match[1] || Regexp.last_match[2]
-          deprecation_warnings << name if Regexp.last_match[2]
-
-          fetch(token.to_sym, stack + [name])
+        value.gsub(/%{(\w+)}/) do
+          fetch(Regexp.last_match[1].to_sym, stack + [name])
         end
       end
-      # rubocop:enable Metrics/AbcSize
 
       def raise_circular_dependency_error(name, stack)
         dependencies = [*stack, name].join(" -> ")
         raise "Circular dependency detected in settings: #{dependencies}"
       end
-
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
-      def print_deprecation_warnings
-        return if deprecation_warnings.empty?
-
-        examples = ""
-        deprecation_warnings.uniq.each do |name|
-          sett = settings[name].inspect
-          old_syntax = sett.gsub(
-            /%<(\w+)>/,
-            Colors.red("%<") + '\1' + Colors.red(">")
-          )
-          new_syntax = sett.gsub(
-            /%<(\w+)>/,
-            Colors.green("%{") + '\1' + Colors.green("}")
-          )
-
-          examples << "\n:#{name}\n\n"
-          examples << "  Replace:   set #{name}: #{old_syntax}\n"
-          examples << "  with this: set #{name}: #{new_syntax}\n"
-        end
-
-        Tomo.logger.warn <<~WARNING
-          There are settings using the deprecated %<...> interpolation syntax.
-          #{examples}
-          #{Colors.red('The %<...> syntax will not work in future versions of tomo.')}
-
-        WARNING
-
-        # Make sure people see the warning!
-        sleep 5
-      end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
 
       def symbolize(hash)
         hash.each_with_object({}) do |(key, value), symbolized|

--- a/test/tomo/runtime/settings_interpolation_test.rb
+++ b/test/tomo/runtime/settings_interpolation_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class Tomo::Runtime::SettingsInterpolationTest < Minitest::Test
-  include Tomo::Testing::LogCapturing
-
   def test_interpolates_settings
     interpolated = interpolate(
       application: "test",
@@ -42,17 +40,15 @@ class Tomo::Runtime::SettingsInterpolationTest < Minitest::Test
     )
   end
 
-  def test_warns_on_old_syntax
-    interpolated = capturing_logger_output do
-      interpolate(application: "default", deploy_to: "/var/www/%<application>")
-    end
-    assert_match(<<~WARNING, stderr)
-        Replace:   set deploy_to: "/var/www/%<application>"
-        with this: set deploy_to: "/var/www/%{application}"
-
-      The %<...> syntax will not work in future versions of tomo.
-    WARNING
-    assert_equal("/var/www/default", interpolated[:deploy_to])
+  def test_no_longer_supports_old_syntax
+    interpolated = interpolate(
+      application: "default",
+      deploy_to: "/var/www/%<application>"
+    )
+    assert_equal(
+      { application: "default", deploy_to: "/var/www/%<application>" },
+      interpolated
+    )
   end
 
   private


### PR DESCRIPTION
The `%<...>` syntax was deprecated in tomo 0.9.0. This PR removes this syntax entirely in favor of the newer `%{...}` syntax.

From #59 :

---

Tomo used to use `%<setting_name>` for string interpolation within settings, in order to allow composition of settings like:

```ruby
set application: "my-app"
set deploy_to: "/var/www/%<application>"
```

That worked great but it went against the grain for how `%<...>` is normally used in Ruby. In Ruby, string formatting (i.e. interpolation) is done in one of three ways:

```ruby
# All of these produce "/var/www/my-app"
format("/var/www/%s", "my-app")
format("/var/www/%<application>s", application: "my-app")
format("/var/www/%{application}", application: "my-app")
```

Notice that in Ruby's [Kernel#format](https://ruby-doc.org/core-2.6.5/Kernel.html#method-i-format), the angle bracket style requires a type specifier (e.g. "s"), like this: `%<application>s`. There isn't a precedent for the tomo style of `%<application>`, i.e. without the "s", and in fact in plain Ruby it would not produce the desired result.

So if tomo is to be consistent with Ruby conventions, the more appropriate syntax is `%{application}`. This style does not use a type.
