### PR TITLE
Use a more reliable way to check linger status

### DIFF
--- a/lib/tomo/plugin/puma/tasks.rb
+++ b/lib/tomo/plugin/puma/tasks.rb
@@ -65,8 +65,10 @@ module Tomo::Plugin::Puma
     end
 
     def linger_must_be_enabled!
-      loginctl_result = remote.run "loginctl", "user-status", remote.host.user
-      return unless loginctl_result.stdout.match?(/^\s*Linger:\s*no\s*$/i)
+      linger_users = remote.list_files(
+        "/var/lib/systemd/linger", raise_on_error: false
+      )
+      return if dry_run? || linger_users.include?(remote.host.user)
 
       die <<~ERROR.strip
         Linger must be enabled for the #{remote.host.user} user in order for

--- a/lib/tomo/testing/Dockerfile
+++ b/lib/tomo/testing/Dockerfile
@@ -7,8 +7,6 @@ COPY ./custom_setup.sh ./
 RUN ./custom_setup.sh
 COPY ./systemctl.rb /usr/local/bin/systemctl
 RUN chmod a+x /usr/local/bin/systemctl
-COPY ./loginctl.sh /usr/local/bin/loginctl
-RUN chmod a+x /usr/local/bin/loginctl
 EXPOSE 22
 EXPOSE 3000
 CMD ["/usr/sbin/sshd", "-D"]

--- a/lib/tomo/testing/docker_image.rb
+++ b/lib/tomo/testing/docker_image.rb
@@ -11,7 +11,6 @@ module Tomo
     class DockerImage
       FILES_TO_COPY = %w[
         Dockerfile
-        loginctl.sh
         systemctl.rb
         tomo_test_ed25519.pub
         ubuntu_setup.sh

--- a/lib/tomo/testing/loginctl.sh
+++ b/lib/tomo/testing/loginctl.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# THIS FILE IS FOR TESTING PURPOSES ONLY.
-#
-# The real loginctl command does not work in a Docker container, so this empty
-# script takes its place, allowing tomo to work during an E2E test.

--- a/lib/tomo/testing/ubuntu_setup.sh
+++ b/lib/tomo/testing/ubuntu_setup.sh
@@ -12,6 +12,8 @@ chown -R deployer:deployer /home/deployer/.ssh
 chmod 600 /home/deployer/.ssh/authorized_keys
 mkdir -p /var/www
 chown deployer:deployer /var/www
+mkdir -p /var/lib/systemd/linger
+touch /var/lib/systemd/linger/deployer
 
 # Packages needed for ruby, etc.
 apt-get -y update

--- a/test/tomo/plugin/puma/tasks_test.rb
+++ b/test/tomo/plugin/puma/tasks_test.rb
@@ -14,8 +14,12 @@ class Tomo::Plugin::Puma::TasksTest < Minitest::Test
   end
 
   def test_setup_systemd
+    @tester.mock_script_result(
+      "ls -A1 /var/lib/systemd/linger",
+      stdout: "testing\n"
+    )
     expected_scripts = [
-      "loginctl user-status testing",
+      "ls -A1 /var/lib/systemd/linger",
       "mkdir -p .config/systemd/user",
       "> .config/systemd/user/puma_test.socket",
       "> .config/systemd/user/puma_test.service",
@@ -31,8 +35,8 @@ class Tomo::Plugin::Puma::TasksTest < Minitest::Test
 
   def test_setup_systemd_dies_if_linger_is_disabled
     @tester.mock_script_result(
-      "loginctl user-status testing",
-      stdout: "Linger: no"
+      "ls -A1 /var/lib/systemd/linger",
+      stdout: "some_other_user\n"
     )
     error = assert_raises(Tomo::Runtime::TaskAbortedError) do
       @tester.run_task("puma:setup_systemd")


### PR DESCRIPTION
Before Ubuntu 18, `loginctl user-status` would not indicate whether linger was enabled. As a result, it was easy to deploy an app via tomo and forget to turn linger on, puma would fail to stay running, and this was hard to troubleshoot.

We can make this more reliable by checking the filesystem for linger status, since what `loginctl enable-linger` does under the hood is just create a file under `/var/lib/systemd/linger/`. Now `tomo:setup_systemd` will provide a helpful error message if linger is not enabled, even on older versions of Ubuntu.