### PR TITLE
Fix keyword parameter warnings in Ruby 2.7

### DIFF
--- a/lib/tomo/cli/command.rb
+++ b/lib/tomo/cli/command.rb
@@ -1,11 +1,18 @@
-require "forwardable"
-
 module Tomo
   class CLI
     class Command
       class << self
-        extend Forwardable
-        def_delegators :parser, :arg, :option, :after_parse
+        def arg(spec, values: [])
+          parser.arg(spec, values: values)
+        end
+
+        def option(key, spec, desc=nil, values: [], &block)
+          parser.option(key, spec, desc, values: values, &block)
+        end
+
+        def after_parse(context_method_name)
+          parser.after_parse(context_method_name)
+        end
 
         def parser
           @parser ||= Parser.new


### PR DESCRIPTION
Currently there are problems with `def_delegators` in Ruby 2.7 with respect to keyword arguments. This causes warnings like:

```
ruby/2.7.0/forwardable.rb:235: warning: The last argument is used as the keyword parameter
```

Work around this in tomo by not using `def_delegators` in some cases.