### PR TITLE
Fix misused double-splat that caused warning in Ruby 2.7

### DIFF
--- a/lib/tomo/remote.rb
+++ b/lib/tomo/remote.rb
@@ -22,7 +22,7 @@ module Tomo
     def attach(*command, default_chdir: nil, **command_opts)
       full_command = shell_builder.build(*command, default_chdir: default_chdir)
       ssh.ssh_exec(
-        Script.new(full_command, { pty: true }.merge(**command_opts))
+        Script.new(full_command, **{ pty: true }.merge(command_opts))
       )
     end
 


### PR DESCRIPTION
This was causing a warning in Ruby 2.7:

```
tomo/remote.rb:25: warning: The last argument is used as the keyword parameter
tomo/script.rb:5: warning: for `initialize' defined here
```