### PR TITLE
Send Rails logs to stdout by default

### DIFF
--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -24,6 +24,7 @@ set git_exclusions: %w[
 set env_vars: {
   RACK_ENV: "production",
   RAILS_ENV: "production",
+  RAILS_LOG_TO_STDOUT: "1",
   RAILS_SERVE_STATIC_FILES: "1",
   DATABASE_URL: :prompt,
   SECRET_KEY_BASE: :prompt


### PR DESCRIPTION
We are using systemd for puma, and systemd has a robust logging system built in. To take advantage of this, Rails has to be configured to send its output to stdout. This is something that Rails supports out of the box via the `RAILS_LOG_TO_STDOUT` environment variable.

Recommend tomo users set this by putting it in the default config file that is generated by `tomo init`.