### PR TITLE
Show friendly error when plugin is missing

### DIFF
--- a/lib/tomo/runtime/unknown_task_error.rb
+++ b/lib/tomo/runtime/unknown_task_error.rb
@@ -9,14 +9,27 @@ module Tomo
           To see a list of all available tasks, run #{blue('tomo tasks')}.
         ERROR
 
-        # TODO: suggest "did you forget to add the <abc> plugin?"
+        sugg = spelling_suggestion || missing_plugin_suggestion
+        error << sugg if sugg
+        error
+      end
 
+      private
+
+      def spelling_suggestion
         sugg = Error::Suggestions.new(
           dictionary: known_tasks,
           word: unknown_task
         )
-        error << sugg.to_console if sugg.any?
-        error
+        sugg.to_console if sugg.any?
+      end
+
+      def missing_plugin_suggestion
+        unknown_plugin = unknown_task[/\A(.+?):/, 1]
+        known_plugins = known_tasks.map { |t| t.split(":").first }.uniq
+        return if unknown_plugin.nil? || known_plugins.include?(unknown_plugin)
+
+        "\nDid you forget to install the #{blue(unknown_plugin)} plugin?"
       end
     end
   end

--- a/test/tomo/cli_test.rb
+++ b/test/tomo/cli_test.rb
@@ -11,6 +11,12 @@ class Tomo::CLITest < Minitest::Test
     assert_match "Simulated bundler:install", @tester.stdout
   end
 
+  def test_suggests_installing_missing_plugin
+    @tester.run "init"
+    @tester.run "foo:setup", raise_on_error: false
+    assert_match(/did you forget to install the foo plugin/i, @tester.stderr)
+  end
+
   def test_prints_error_when_config_has_syntax_error
     @tester.in_temp_dir do
       FileUtils.mkdir_p(".tomo")


### PR DESCRIPTION
If you try to run a task but the namespace of the task is not recognized, tomo will now helpfully suggest that you may need to load the plugin that defines that namespace. E.g.

```
$ tomo run sidekiq:setup
tomo run v0.12.0

  ERROR: sidekiq:setup is not a recognized task.
  To see a list of all available tasks, run tomo tasks.

  Did you forget to install the sidekiq plugin?
```