### PR TITLE
Describe execution plan when --debug is used

### DIFF
--- a/docs/commands/deploy.md
+++ b/docs/commands/deploy.md
@@ -40,6 +40,8 @@ The directory structure on the remote host looks like this:
 
 This structure is customizable; see the [core plugin settings](../plugins/core.md#settings) for details.
 
+Tip: run `tomo deploy --debug --dry-run` to see an in-depth explanation of the settings and execution plan that will be used for the deployment.
+
 ## Options
 
 | Option | Purpose |

--- a/lib/tomo/commands/deploy.rb
+++ b/lib/tomo/commands/deploy.rb
@@ -15,7 +15,9 @@ module Tomo
 
           Sequentially run the "deploy" list of tasks specified in #{DEFAULT_CONFIG_PATH} to
           deploy the project to a remote host. Use the #{blue('--dry-run')} option to quickly
-          simulate the entire deploy without actually connecting to the host.
+          simulate the entire deploy without actually connecting to the host. Add the
+          #{blue('--debug')} option to see an in-depth explanation of the settings and execution
+          plan that will be used for the deployment
 
           For a #{DEFAULT_CONFIG_PATH} that specifies distinct environments (e.g. staging,
           production), you must specify the target environment using the #{blue('-e')} option. If

--- a/lib/tomo/runtime.rb
+++ b/lib/tomo/runtime.rb
@@ -8,6 +8,7 @@ module Tomo
     autoload :Context, "tomo/runtime/context"
     autoload :Current, "tomo/runtime/current"
     autoload :ExecutionPlan, "tomo/runtime/execution_plan"
+    autoload :Explanation, "tomo/runtime/explanation"
     autoload :HostExecutionStep, "tomo/runtime/host_execution_step"
     autoload :InlineThreadPool, "tomo/runtime/inline_thread_pool"
     autoload :NoTasksError, "tomo/runtime/no_tasks_error"

--- a/lib/tomo/runtime/explanation.rb
+++ b/lib/tomo/runtime/explanation.rb
@@ -1,0 +1,44 @@
+module Tomo
+  class Runtime
+    class Explanation
+      def initialize(applicable_hosts, plan, concurrency)
+        @applicable_hosts = applicable_hosts
+        @plan = plan
+        @concurrency = concurrency
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def to_s
+        desc = []
+        threads = [applicable_hosts.length, concurrency].min
+        desc << "CONCURRENTLY (#{threads} THREADS):" if threads > 1
+        applicable_hosts.each do |host|
+          indent = threads > 1 ? "  = " : ""
+          desc << "#{indent}CONNECT #{host}"
+        end
+        plan.each do |steps|
+          threads = [steps.length, concurrency].min
+          desc << "CONCURRENTLY (#{threads} THREADS):" if threads > 1
+          steps.each do |step|
+            indent = threads > 1 ? "  = " : ""
+            if threads > 1 && step.applicable_tasks.length > 1
+              desc << "#{indent}IN SEQUENCE:"
+              indent.sub!(/=/, "   ")
+            end
+            desc << step.explain.gsub(/^/, indent)
+          end
+        end
+        desc.join("\n")
+      end
+      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/CyclomaticComplexity
+
+      private
+
+      attr_reader :applicable_hosts, :plan, :concurrency
+    end
+  end
+end

--- a/lib/tomo/runtime/host_execution_step.rb
+++ b/lib/tomo/runtime/host_execution_step.rb
@@ -30,6 +30,15 @@ module Tomo
         end
       end
 
+      def explain
+        desc = []
+        applicable_tasks.each do |task|
+          task_host = task.is_a?(PrivilegedTask) ? host.as_privileged : host
+          desc << "RUN #{task} ON #{task_host}"
+        end
+        desc.join("\n")
+      end
+
       private
 
       attr_reader :host, :task_runner

--- a/test/tomo/runtime/execution_plan_test.rb
+++ b/test/tomo/runtime/execution_plan_test.rb
@@ -1,0 +1,219 @@
+require "test_helper"
+
+class Tomo::Runtime::ExecutionPlanTest < Minitest::Test
+  def test_single_host_run_plan
+    runtime = single_host_config.build_runtime
+    plan = runtime.execution_plan_for(["core:clean_releases"])
+    assert_equal(<<~PLAN.strip, plan.explain)
+      CONNECT deployer@app.example.com
+      RUN core:clean_releases ON deployer@app.example.com
+    PLAN
+  end
+
+  def test_multi_host_run_plan
+    runtime = role_based_multi_host_config.build_runtime
+    plan = runtime.execution_plan_for(["core:clean_releases"])
+    assert_equal(<<~PLAN.strip, plan.explain)
+      CONCURRENTLY (2 THREADS):
+        = CONNECT deployer@worker.example.com
+        = CONNECT deployer@web.example.com
+      CONCURRENTLY (2 THREADS):
+        = RUN core:clean_releases ON deployer@worker.example.com
+        = RUN core:clean_releases ON deployer@web.example.com
+    PLAN
+  end
+
+  def test_multi_host_run_plan_with_no_concurrency
+    config = role_based_multi_host_config
+    config.settings[:concurrency] = 1
+    runtime = config.build_runtime
+    plan = runtime.execution_plan_for(["core:clean_releases"])
+    assert_equal(<<~PLAN.strip, plan.explain)
+      CONNECT deployer@worker.example.com
+      CONNECT deployer@web.example.com
+      RUN core:clean_releases ON deployer@worker.example.com
+      RUN core:clean_releases ON deployer@web.example.com
+    PLAN
+  end
+
+  def test_single_host_setup_plan
+    runtime = single_host_config.build_runtime
+    plan = runtime.execution_plan_for(setup_tasks)
+    assert_equal(<<~PLAN.strip, plan.explain)
+      CONNECT deployer@app.example.com
+      RUN env:setup ON deployer@app.example.com
+      RUN nodenv:install ON deployer@app.example.com
+      RUN rbenv:install ON deployer@app.example.com
+    PLAN
+  end
+
+  def test_multi_host_setup_plan
+    runtime = role_based_multi_host_config.build_runtime
+    plan = runtime.execution_plan_for(setup_tasks)
+    assert_equal(<<~PLAN.strip, plan.explain)
+      CONCURRENTLY (2 THREADS):
+        = CONNECT deployer@worker.example.com
+        = CONNECT deployer@web.example.com
+      CONCURRENTLY (2 THREADS):
+        = RUN env:setup ON deployer@worker.example.com
+        = RUN env:setup ON deployer@web.example.com
+      CONCURRENTLY (2 THREADS):
+        = RUN nodenv:install ON deployer@worker.example.com
+        = RUN nodenv:install ON deployer@web.example.com
+      CONCURRENTLY (2 THREADS):
+        = RUN rbenv:install ON deployer@worker.example.com
+        = RUN rbenv:install ON deployer@web.example.com
+    PLAN
+  end
+
+  def test_multi_host_setup_plan_with_no_concurrency
+    config = role_based_multi_host_config
+    config.settings[:concurrency] = 1
+    runtime = config.build_runtime
+    plan = runtime.execution_plan_for(setup_tasks)
+    assert_equal(<<~PLAN.strip, plan.explain)
+      CONNECT deployer@worker.example.com
+      CONNECT deployer@web.example.com
+      RUN env:setup ON deployer@worker.example.com
+      RUN env:setup ON deployer@web.example.com
+      RUN nodenv:install ON deployer@worker.example.com
+      RUN nodenv:install ON deployer@web.example.com
+      RUN rbenv:install ON deployer@worker.example.com
+      RUN rbenv:install ON deployer@web.example.com
+    PLAN
+  end
+
+  def test_single_host_setup_plan_with_privileged_task
+    config = single_host_config
+    runtime = config.build_runtime
+    plan = runtime.execution_plan_for(
+      setup_tasks + ["puma:setup_systemd".extend(Tomo::Runtime::PrivilegedTask)]
+    )
+    assert_equal(<<~PLAN.strip, plan.explain)
+      CONCURRENTLY (2 THREADS):
+        = CONNECT deployer@app.example.com
+        = CONNECT root@app.example.com
+      RUN env:setup ON deployer@app.example.com
+      RUN nodenv:install ON deployer@app.example.com
+      RUN rbenv:install ON deployer@app.example.com
+      RUN puma:setup_systemd ON root@app.example.com
+    PLAN
+  end
+
+  def test_multi_host_setup_plan_with_privileged_task
+    config = role_based_multi_host_config
+    runtime = config.build_runtime
+    plan = runtime.execution_plan_for(
+      setup_tasks + ["puma:setup_systemd".extend(Tomo::Runtime::PrivilegedTask)]
+    )
+    assert_equal(<<~PLAN.strip, plan.explain)
+      CONCURRENTLY (3 THREADS):
+        = CONNECT deployer@worker.example.com
+        = CONNECT deployer@web.example.com
+        = CONNECT root@web.example.com
+      CONCURRENTLY (2 THREADS):
+        = RUN env:setup ON deployer@worker.example.com
+        = RUN env:setup ON deployer@web.example.com
+      CONCURRENTLY (2 THREADS):
+        = RUN nodenv:install ON deployer@worker.example.com
+        = RUN nodenv:install ON deployer@web.example.com
+      CONCURRENTLY (2 THREADS):
+        = RUN rbenv:install ON deployer@worker.example.com
+        = RUN rbenv:install ON deployer@web.example.com
+      RUN puma:setup_systemd ON root@web.example.com
+    PLAN
+  end
+
+  def test_single_host_deploy_plan_with_batches
+    runtime = single_host_config.build_runtime
+    plan = runtime.execution_plan_for(deploy_tasks_with_batches)
+    assert_equal(<<~PLAN.strip, plan.explain)
+      CONNECT deployer@app.example.com
+      RUN env:update ON deployer@app.example.com
+      RUN git:create_release ON deployer@app.example.com
+      RUN bundler:install ON deployer@app.example.com
+      RUN core:symlink_current ON deployer@app.example.com
+      RUN puma:restart ON deployer@app.example.com
+      RUN core:clean_releases ON deployer@app.example.com
+      RUN core:log_revision ON deployer@app.example.com
+    PLAN
+  end
+
+  def test_multi_host_deploy_plan_with_batches
+    runtime = role_based_multi_host_config.build_runtime
+    plan = runtime.execution_plan_for(deploy_tasks_with_batches)
+    assert_equal(<<~PLAN.strip, plan.explain)
+      CONCURRENTLY (2 THREADS):
+        = CONNECT deployer@worker.example.com
+        = CONNECT deployer@web.example.com
+      CONCURRENTLY (2 THREADS):
+        = IN SEQUENCE:
+            RUN env:update ON deployer@worker.example.com
+            RUN git:create_release ON deployer@worker.example.com
+            RUN bundler:install ON deployer@worker.example.com
+        = IN SEQUENCE:
+            RUN env:update ON deployer@web.example.com
+            RUN git:create_release ON deployer@web.example.com
+            RUN bundler:install ON deployer@web.example.com
+      CONCURRENTLY (2 THREADS):
+        = RUN core:symlink_current ON deployer@worker.example.com
+        = RUN core:symlink_current ON deployer@web.example.com
+      CONCURRENTLY (2 THREADS):
+        = IN SEQUENCE:
+            RUN core:clean_releases ON deployer@worker.example.com
+            RUN core:log_revision ON deployer@worker.example.com
+        = IN SEQUENCE:
+            RUN puma:restart ON deployer@web.example.com
+            RUN core:clean_releases ON deployer@web.example.com
+            RUN core:log_revision ON deployer@web.example.com
+    PLAN
+  end
+
+  private
+
+  def setup_tasks
+    %w[
+      env:setup
+      nodenv:install
+      rbenv:install
+    ]
+  end
+
+  def deploy_tasks_with_batches
+    [
+      [
+        "env:update",
+        "git:create_release",
+        "bundler:install"
+      ],
+      "core:symlink_current",
+      [
+        "puma:restart",
+        "core:clean_releases",
+        "core:log_revision"
+      ]
+    ]
+  end
+
+  def base_config
+    Tomo::Configuration.new.tap do |config|
+      config.plugins = %w[env git nodenv rbenv bundler rails puma]
+    end
+  end
+
+  def single_host_config
+    base_config.tap do |config|
+      config.hosts << Tomo::Host.parse("deployer@app.example.com")
+    end
+  end
+
+  def role_based_multi_host_config
+    base_config.tap do |config|
+      config.task_filter.add_role("puma", ["puma:*"])
+      config.hosts << Tomo::Host.parse("deployer@worker.example.com")
+      config.hosts << Tomo::Host.parse(
+        "deployer@web.example.com", roles: ["puma"]
+      )
+    end
+  end
+end


### PR DESCRIPTION
One of the tricker parts of tomo's implementation is how it translates a configuration into an "execution plan" that automatically connects to appropriate hosts and schedules tasks onto a thread pool for running on many hosts at once.

This PR gives users the ability to ask tomo for an "explanation" of this execution plan by passing `--debug` option to `tomo deploy` (or `run` or `setup`). This can come in handy for troubleshooting more complex deployments that involve multiple hosts, roles, and task batches.

Here is an example explanation for a deployment that has 2 hosts, batches, and a "db" role:

```
CONCURRENTLY (2 THREADS):
  = CONNECT deployer@app1.example.com
  = CONNECT deployer@app2.example.com
CONCURRENTLY (2 THREADS):
  = IN SEQUENCE:
      RUN env:update ON deployer@app1.example.com
      RUN git:create_release ON deployer@app1.example.com
      RUN core:symlink_shared ON deployer@app1.example.com
      RUN core:write_release_json ON deployer@app1.example.com
      RUN bundler:install ON deployer@app1.example.com
      RUN rails:assets_precompile ON deployer@app1.example.com
      RUN rails:db_migrate ON deployer@app1.example.com
  = IN SEQUENCE:
      RUN env:update ON deployer@app2.example.com
      RUN git:create_release ON deployer@app2.example.com
      RUN core:symlink_shared ON deployer@app2.example.com
      RUN core:write_release_json ON deployer@app2.example.com
      RUN bundler:install ON deployer@app2.example.com
      RUN rails:assets_precompile ON deployer@app2.example.com
CONCURRENTLY (2 THREADS):
  = RUN core:symlink_current ON deployer@app1.example.com
  = RUN core:symlink_current ON deployer@app2.example.com
CONCURRENTLY (2 THREADS):
  = IN SEQUENCE:
      RUN puma:restart ON deployer@app1.example.com
      RUN core:clean_releases ON deployer@app1.example.com
      RUN bundler:clean ON deployer@app1.example.com
      RUN core:log_revision ON deployer@app1.example.com
  = IN SEQUENCE:
      RUN puma:restart ON deployer@app2.example.com
      RUN core:clean_releases ON deployer@app2.example.com
      RUN bundler:clean ON deployer@app2.example.com
      RUN core:log_revision ON deployer@app2.example.com
```

This PR also uses these explanations to add much-needed test coverage for `Tomo::Runtime::ExecutionPlan`.