### PR TITLE
Include `public/packs` in linked_dirs for better webpacker support

### DIFF
--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -33,6 +33,7 @@ set linked_dirs: %w[
   log
   node_modules
   public/assets
+  public/packs
   tmp/cache
   tmp/pids
   tmp/sockets


### PR DESCRIPTION
The official webpacker deployment documentation recommends that `public/packs` and `node_modudles` be included in `linked_dirs`, so that webpack compilation does not have be redone from scratch for every release.

https://github.com/rails/webpacker/blob/master/docs/deployment.md

We already link `node_modules` but `public/packs` was missing. This commit adds it to the default `linked_dirs` generated by `tomo init` so that it is included in new tomo projects going forward.