### PR TITLE
Improve console detection; treat CI as non-interactive

### DIFF
--- a/lib/tomo/console.rb
+++ b/lib/tomo/console.rb
@@ -1,33 +1,80 @@
+require "forwardable"
 require "io/console"
 
 module Tomo
-  module Console
+  class Console
     autoload :KeyReader, "tomo/console/key_reader"
     autoload :Menu, "tomo/console/menu"
 
     class << self
-      def interactive?(input=$stdin)
-        input.respond_to?(:raw) && input.respond_to?(:tty?) && input.tty?
-      end
+      extend Forwardable
+      def_delegators :@instance, :interactive?, :prompt, :menu
+    end
 
-      def prompt(question)
-        assert_interactive
+    def initialize(env=ENV, input=$stdin)
+      @env = env
+      @input = input
+    end
 
-        print question
-        $stdin.gets.chomp
-      end
+    def interactive?
+      input.respond_to?(:raw) &&
+        input.respond_to?(:tty?) &&
+        input.tty? &&
+        !ci?
+    end
 
-      def menu(question, choices:)
-        assert_interactive
+    def prompt(question)
+      assert_interactive
 
-        Menu.new(question, choices).prompt_for_selection
-      end
+      print question
+      line = input.gets
+      raise_non_interactive if line.nil?
 
-      private
+      line.chomp
+    end
 
-      def assert_interactive
-        raise "An interactive console is required" unless interactive?
-      end
+    def menu(question, choices:)
+      assert_interactive
+
+      Menu.new(question, choices).prompt_for_selection
+    end
+
+    private
+
+    attr_reader :env, :input
+
+    CI_VARS = %w[
+      JENKINS_HOME
+      JENKINS_URL
+      TRAVIS
+      CIRCLECI
+      CI
+      TEAMCITY_VERSION
+      GO_PIPELINE_NAME
+      bamboo_buildKey
+      GITLAB_CI
+      XCS
+    ].freeze
+    private_constant :CI_VARS
+
+    def ci?
+      (env.keys & CI_VARS).any?
+    end
+
+    def assert_interactive
+      raise_non_interactive unless interactive?
+    end
+
+    def raise_non_interactive
+      raise "An interactive console is required" unless ci?
+
+      env_var = (env.keys & CI_VARS).first
+      raise <<~ERROR
+        This appears to be a CI environment because the #{env_var} env var is set.
+        Tomo::Console cannot be used in a non-interactive CI environment.
+      ERROR
     end
   end
 end
+
+Tomo::Console.instance_variable_set :@instance, Tomo::Console.new

--- a/lib/tomo/console/key_reader.rb
+++ b/lib/tomo/console/key_reader.rb
@@ -3,7 +3,7 @@ require "io/console"
 require "time"
 
 module Tomo
-  module Console
+  class Console
     class KeyReader
       extend Forwardable
 

--- a/lib/tomo/console/menu.rb
+++ b/lib/tomo/console/menu.rb
@@ -2,7 +2,7 @@ require "forwardable"
 require "io/console"
 
 module Tomo
-  module Console
+  class Console
     class Menu
       ARROW_UP = "\e[A".freeze
       ARROW_DOWN = "\e[B".freeze

--- a/test/tomo/console_test.rb
+++ b/test/tomo/console_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class Tomo::ConsoleTest < Minitest::Test
+  def test_interactive_is_true_for_tty
+    assert Tomo::Console.new({}, tty).interactive?
+  end
+
+  def test_interactive_is_false_for_ci_env
+    refute Tomo::Console.new({ "CIRCLECI" => "1" }, tty).interactive?
+  end
+
+  def test_interactive_is_false_non_tty
+    refute Tomo::Console.new({}, non_tty).interactive?
+  end
+
+  def prompt_answer_does_not_contain_newline
+    console = Tomo::Console.new({}, tty("yes\n"))
+    answer = console.prompt("Are you sure? ")
+    assert_equal("yes", answer)
+  end
+
+  def prompt_raises_if_not_tty
+    console = Tomo::Console.new({}, non_tty("yes\n"))
+    error = assert_raises { console.prompt("Are you sure? ") }
+    assert_match(/interactive console is required/i, error.message)
+  end
+
+  def prompt_raises_if_ci
+    console = Tomo::Console.new({ "CIRCLECI" => "1" }, tty("yes\n"))
+    error = assert_raises { console.prompt("Are you sure? ") }
+    assert_match(/appears to be a CI environment/i, error.message)
+  end
+
+  def menu_raises_if_not_tty
+    console = Tomo::Console.new({}, non_tty("yes\n"))
+    error = assert_raises { console.menu("Are you sure? ", choices: %w[y n]) }
+    assert_match(/interactive console is required/i, error.message)
+  end
+
+  def menu_raises_if_ci
+    console = Tomo::Console.new({ "CIRCLECI" => "1" }, tty("yes\n"))
+    error = assert_raises { console.menu("Are you sure? ", choices: %w[y n]) }
+    assert_match(/appears to be a CI environment/i, error.message)
+  end
+
+  private
+
+  def tty(data="")
+    StringIO.new(data).tap do |io|
+      def io.raw
+      end
+
+      def io.tty?
+        true
+      end
+    end
+  end
+
+  def non_tty(data="")
+    StringIO.new(data)
+  end
+end


### PR DESCRIPTION
CI is by definition an non-interactive environment. However, before, tomo was not able to detect this reliably. As a result, if a tomo deploy used something like `Console.prompt` or `Console.menu`, this would crash or hang indefinitely.

This commit improves how non-interactive environments are detected so that tomo exits with a more descriptive error instead of hanging.

- Use env vars to detect whether tomo is running in CI.
- Treat CI environment as non-interactive.
- Console.prompt will now explicitly raise instead of crashing on `nil`.
- Refactor Tomo::Console into a singleton class to facilitate testing.
- Add test coverage.