### PR TITLE
Improve env:update output and error handling

### DIFF
--- a/lib/tomo/console.rb
+++ b/lib/tomo/console.rb
@@ -46,14 +46,13 @@ module Tomo
     CI_VARS = %w[
       JENKINS_HOME
       JENKINS_URL
+      GITHUB_ACTION
       TRAVIS
       CIRCLECI
-      CI
       TEAMCITY_VERSION
-      GO_PIPELINE_NAME
       bamboo_buildKey
       GITLAB_CI
-      XCS
+      CI
     ].freeze
     private_constant :CI_VARS
 

--- a/lib/tomo/console.rb
+++ b/lib/tomo/console.rb
@@ -5,6 +5,7 @@ module Tomo
   class Console
     autoload :KeyReader, "tomo/console/key_reader"
     autoload :Menu, "tomo/console/menu"
+    autoload :NonInteractiveError, "tomo/console/non_interactive_error"
 
     class << self
       extend Forwardable
@@ -65,13 +66,10 @@ module Tomo
     end
 
     def raise_non_interactive
-      raise "An interactive console is required" unless ci?
-
-      env_var = (env.keys & CI_VARS).first
-      raise <<~ERROR
-        This appears to be a CI environment because the #{env_var} env var is set.
-        Tomo::Console cannot be used in a non-interactive CI environment.
-      ERROR
+      NonInteractiveError.raise_with(
+        task: Runtime::Current.task,
+        ci_var: (env.keys & CI_VARS).first
+      )
     end
   end
 end

--- a/lib/tomo/console/non_interactive_error.rb
+++ b/lib/tomo/console/non_interactive_error.rb
@@ -1,0 +1,27 @@
+module Tomo
+  class Console
+    class NonInteractiveError < Tomo::Error
+      attr_accessor :task, :ci_var
+
+      def to_console
+        error = ""
+        error << "#{operation_name} requires an interactive console."
+        error << "\n\n#{seems_like_ci}" if ci_var
+        error
+      end
+
+      private
+
+      def seems_like_ci
+        <<~ERROR
+          This appears to be a non-interactive CI environment because the
+          #{yellow(ci_var)} environment variable is set.
+        ERROR
+      end
+
+      def operation_name
+        task ? "The #{yellow(task)} task" : "Tomo::Console"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR makes some usability improvements to the `env:update` task:

- Explain why tomo is prompting for a value
- Don't show a giant stack trace if prompting fails due to a non-interactive console.

For example, let's say tomo is running a deploy in a CI environment, and the `env:update` task fails because a required environment variable is missing and an interactive console is needed.

Before, the user would see a stack trace with a message that an interactive console was needed, but not _why_ it was needed.

Now the error is much more concise and there is an explanation of why tomo needs an interactive console:

```
$ tomo deploy
tomo deploy v0.17.0
→ Connecting to deployer@app.example.com
• env:update
The remote host needs a value for the $FOO environment variable.
Please provide a value at the prompt.

  ERROR: The env:update task requires an interactive console.

  This appears to be a non-interactive CI environment because the
  CIRCLECI environment variable is set.
```