### PR TITLE
Further fixes for styles broken by mkdocs 1.1

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -32,18 +32,16 @@ pre + h3 {
   margin-top: 30px;
 }
 
-pre > code,
+.rst-content pre > code,
 .hljs {
-  background-color: #f8f8f8;
   line-height: 1.5;
-  padding: 10px 12px;
 }
 
 table {
   border-radius: 2px;
 }
 
-td > code {
+.rst-content td > code {
   white-space: nowrap;
 }
 


### PR DESCRIPTION
- Don't wrap `<code>` inside table cells