### PR TITLE
Fail loudly if tomo cannot guess bundler version

### DIFF
--- a/docs/plugins/bundler.md
+++ b/docs/plugins/bundler.md
@@ -21,7 +21,7 @@ Note that the settings listed here only take effect if you run the [bundler:conf
 
 ### bundler:upgrade_bundler
 
-Installs the version of bundler specified by the `:bundler_version` setting, if specified. If `:bundler_version` is `nil` (the default), this task will automatically determine the version of bundler required by the app that is being deployed by looking at the `BUNDLED WITH` entry within the app’s `Gemfile.lock`. If `:bundler_version` is `nil` and the app is missing a lockfile, then this task does nothing. Bundler will be installed withing this command:
+Installs the version of bundler specified by the `:bundler_version` setting, if specified. If `:bundler_version` is `nil` (the default), this task will automatically determine the version of bundler required by the app that is being deployed by looking at the `BUNDLED WITH` entry within the app’s `Gemfile.lock`. Bundler will be installed withing this command:
 
 ```
 gem install bundler --conservative --no-document -v VERSION

--- a/lib/tomo/plugin/bundler/tasks.rb
+++ b/lib/tomo/plugin/bundler/tasks.rb
@@ -30,7 +30,6 @@ module Tomo::Plugin::Bundler
 
     def upgrade_bundler
       needed_bundler_ver = version_setting || extract_bundler_ver_from_lockfile
-      return if needed_bundler_ver.nil?
 
       remote.run(
         "gem", "install", "bundler",
@@ -61,7 +60,13 @@ module Tomo::Plugin::Bundler
         "tail", "-n", "10", paths.release.join("Gemfile.lock"),
         raise_on_error: false
       )
-      lockfile_tail[/BUNDLED WITH\n   (\S+)$/, 1]
+      version = lockfile_tail[/BUNDLED WITH\n   (\S+)$/, 1]
+      return version if version
+
+      die <<~REASON
+        Could not guess bundler version from Gemfile.lock.
+        Use the :bundler_version setting to specify the version of bundler to install.
+      REASON
     end
   end
 end

--- a/test/tomo/plugin/bundler/tasks_test.rb
+++ b/test/tomo/plugin/bundler/tasks_test.rb
@@ -90,7 +90,7 @@ class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
     )
   end
 
-  def test_dies_if_lock_file_is_absent_and_no_version_specified
+  def test_upgrade_bundler_dies_if_lock_file_is_absent_and_no_version_specified
     tester = configure(bundler_version: nil)
     tester.mock_script_result(/^tail .*Gemfile\.lock/, exit_status: 1)
     error = assert_raises(Tomo::Runtime::TaskAbortedError) do

--- a/test/tomo/plugin/bundler/tasks_test.rb
+++ b/test/tomo/plugin/bundler/tasks_test.rb
@@ -90,10 +90,13 @@ class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
     )
   end
 
-  def test_upgrade_bundler_skips_installation_if_lock_file_is_absent
-    tester = configure
+  def test_dies_if_lock_file_is_absent_and_no_version_specified
+    tester = configure(bundler_version: nil)
     tester.mock_script_result(/^tail .*Gemfile\.lock/, exit_status: 1)
-    tester.run_task("bundler:upgrade_bundler")
+    error = assert_raises(Tomo::Runtime::TaskAbortedError) do
+      tester.run_task("bundler:upgrade_bundler")
+    end
+    assert_match(/Gemfile\.lock/, error.message)
     assert_match(/tail .*Gemfile\.lock/, tester.executed_script)
   end
 


### PR DESCRIPTION
If `:bundler_version` is not specified, tomo will try to guess the desired version by extracting the `BUNDLED WITH` value from the `Gemfile.lock`.

Before, if this fails (e.g. because the lock file is missing), the `bundler:upgrade_bundler` task would silently do nothing. This is surprising because no other tomo task behaves like this.

Now, `bundler:upgrade_bundler` will fail with a helpful error message if the bundler version cannot be determined. If you do not want to use tomo to manage the installation of bundler, it is easy to just remove the `bundler:upgrade_bundler` from the list of setup tasks instead of having it fail silently.