### PR TITLE
Ensure puma starts eagerly on system boot

### DIFF
--- a/lib/tomo/plugin/puma/systemd/service.erb
+++ b/lib/tomo/plugin/puma/systemd/service.erb
@@ -19,4 +19,4 @@ WorkingDirectory=<%= paths.current %>
 # Environment=PUMA_DEBUG=1
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
We install puma as a user-level systemd service. For user-level services, `WantedBy=multi-user.target` does not do anything. That meant that puma would not get started automatically on boot. Socket activation means that puma would still start automatically the first time an HTTP request was received, but this first request would be slow.

Fix by changing to `WantedBy=default.target`. Now puma will start eagerly on boot, ensuring a fast response the first time an HTTP request is received.

To take advantage of this new behavior, re-run:

```
$ tomo run puma:setup_systemd
```