### PR TITLE
Fix NoMethodError in env:setup when env_vars contains an integer

### DIFF
--- a/lib/tomo/plugin/env/tasks.rb
+++ b/lib/tomo/plugin/env/tasks.rb
@@ -82,7 +82,7 @@ module Tomo::Plugin::Env
 
     def prepend_entry(text, name, value)
       text.prepend("\n") unless text.start_with?("\n")
-      text.prepend("export #{name.to_s.shellescape}=#{value.shellescape}")
+      text.prepend("export #{name.to_s.shellescape}=#{value.to_s.shellescape}")
     end
 
     def contains_entry?(text, name)

--- a/test/tomo/plugin/env/tasks_test.rb
+++ b/test/tomo/plugin/env/tasks_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+require "tomo/plugin/env"
+
+class Tomo::Plugin::Env::TasksTest < Minitest::Test
+  def test_setup_allows_integer_value
+    tester = Tomo::Testing::MockPluginTester.new(
+      "env",
+      settings: {
+        env_path: "/app/envrc",
+        env_vars: {
+          RAILS_ENV: "production",
+          RAILS_MAX_THREADS: 6
+        }
+      }
+    )
+    tester.run_task("env:setup")
+    assert_equal(<<~'EXPECTED'.strip, tester.executed_scripts[2])
+      echo -n export\ RAILS_MAX_THREADS\=6'
+      'export\ RAILS_ENV\=production'
+      ' > /app/envrc
+    EXPECTED
+  end
+end


### PR DESCRIPTION
Fixes #128 