### PR TITLE
Use rake to invoke rake tasks, not rails

### DIFF
--- a/lib/tomo/plugin/rails/helpers.rb
+++ b/lib/tomo/plugin/rails/helpers.rb
@@ -7,7 +7,7 @@ module Tomo::Plugin::Rails
     end
 
     def rake(*args, **opts)
-      prepend("exec", "rails") do
+      prepend("exec", "rake") do
         bundle(*args, **opts)
       end
     end

--- a/test/tomo/plugin/rails/helpers_test.rb
+++ b/test/tomo/plugin/rails/helpers_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+require "tomo/plugin/rails"
+
+class Tomo::Plugin::Rails::HelpersTest < Minitest::Test
+  def test_rake_runs_bundle_exec_rake_in_current_path
+    tester = Tomo::Testing::MockPluginTester.new(
+      "bundler", "rails", settings: { current_path: "/app/current" }
+    )
+    tester.call_helper(:rake, "db:migrate")
+    assert_equal(
+      "cd /app/current && bundle exec rake db:migrate",
+      tester.executed_script
+    )
+  end
+end


### PR DESCRIPTION
The documentation for tomo's `rake` helper, and the intent of that method, is that it runs `bundle exec rake`. However this `rake` helper was in fact running `bundle exec rails` instead. This was a mistake.

Fix this so that the `rake` helper, and tasks that depend on it (e.g. `rails:db_migrate`, `rails:db_seed`, etc.) use `bundle exec rake` instead of `bundle exec rails` as originally intended.

This also makes tomo compatible with older versions of Rails, before the `rails` was smart enough to be able to invoke rake tasks.