### PR TITLE
Reformat Ruby files for line length of 120

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,8 +21,7 @@ Layout/HashAlignment:
     - key
 
 Layout/LineLength:
-  Exclude:
-    - "*.gemspec"
+  Max: 120
 
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space

--- a/Rakefile
+++ b/Rakefile
@@ -11,8 +11,7 @@ RuboCop::RakeTask.new
 Rake::TestTask.new("test:unit") do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"] -
-                 FileList["test/**/*_e2e_test.rb"]
+  t.test_files = FileList["test/**/*_test.rb"] - FileList["test/**/*_e2e_test.rb"]
 end
 
 Rake::TestTask.new("test:e2e") do |t|
@@ -44,12 +43,9 @@ namespace :bump do
 
     replace_in_file "tomo.gemspec", /ruby_version = ">= (.*)"/ => lowest
     replace_in_file ".rubocop.yml", /TargetRubyVersion: (.*)/ => lowest_minor
-    replace_in_file ".circleci/config.yml",
-                    %r{circleci/ruby:([\d\.]+)} => latest
-    replace_in_file ".circleci/Dockerfile",
-                    %r{circleci/ruby:([\d\.]+)} => latest
-    replace_in_file "docs/comparisons.md",
-                    /ruby version\s*\|\s*([\d\.]+)/i => lowest_minor
+    replace_in_file ".circleci/config.yml", %r{circleci/ruby:([\d\.]+)} => latest
+    replace_in_file ".circleci/Dockerfile", %r{circleci/ruby:([\d\.]+)} => latest
+    replace_in_file "docs/comparisons.md", /ruby version\s*\|\s*([\d\.]+)/i => lowest_minor
 
     travis = YAML.safe_load(open(".travis.yml"))
     travis["rvm"] = RubyVersions.latest_supported_patches + ["ruby-head"]
@@ -100,9 +96,7 @@ module RubyVersions
 
     def versions
       @_versions ||= begin
-        yaml = URI.open(
-          "https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/downloads.yml"
-        )
+        yaml = URI.open("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/downloads.yml")
         YAML.safe_load(yaml, symbolize_names: true)
       end
     end

--- a/lib/tomo/cli.rb
+++ b/lib/tomo/cli.rb
@@ -55,8 +55,7 @@ module Tomo
       argv << "" if argv.shift == "--complete"
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity
-    def lookup_command(argv)
+    def lookup_command(argv) # rubocop:disable Metrics/CyclomaticComplexity
       command_name = argv.first unless Completions.active? && argv.length == 1
       command_name = Abbrev.abbrev(COMMANDS.keys)[command_name]
       argv.shift if command_name
@@ -65,7 +64,6 @@ module Tomo
       command = COMMANDS[command_name] || Tomo::Commands::Default
       [command, command_name]
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
 
     def task_format?(arg)
       arg.to_s.match?(/\A\S+:\S*\z/)

--- a/lib/tomo/cli/common_options.rb
+++ b/lib/tomo/cli/common_options.rb
@@ -1,22 +1,15 @@
 module Tomo
   class CLI
     module CommonOptions
-      # rubocop:disable Metrics/MethodLength
-      def self.included(mod)
+      def self.included(mod) # rubocop:disable Metrics/MethodLength
         mod.class_eval do
-          option :color,
-                 "--[no-]color",
-                 "Enable/disable color output" do |color|
+          option :color, "--[no-]color", "Enable/disable color output" do |color|
             Colors.enabled = color
           end
-          option :debug,
-                 "--[no-]debug",
-                 "Enable/disable verbose debug logging" do |debug|
+          option :debug, "--[no-]debug", "Enable/disable verbose debug logging" do |debug|
             Tomo.debug = debug
           end
-          option :trace,
-                 "--[no-]trace",
-                 "Display full backtrace on error" do |trace|
+          option :trace, "--[no-]trace", "Display full backtrace on error" do |trace|
             CLI.show_backtrace = trace
           end
           option :help, "-h, --help", "Print this documentation" do |_help|
@@ -27,7 +20,6 @@ module Tomo
           after_parse :dump_runtime_info
         end
       end
-      # rubocop:enable Metrics/MethodLength
 
       private
 

--- a/lib/tomo/cli/deploy_options.rb
+++ b/lib/tomo/cli/deploy_options.rb
@@ -1,8 +1,7 @@
 module Tomo
   class CLI
     module DeployOptions
-      # rubocop:disable Metrics/MethodLength
-      def self.included(mod)
+      def self.included(mod) # rubocop:disable Metrics/MethodLength
         mod.class_eval do
           option :environment,
                  "-e, --environment ENVIRONMENT",
@@ -23,7 +22,6 @@ module Tomo
           after_parse :prompt_for_environment
         end
       end
-      # rubocop:enable Metrics/MethodLength
 
       private
 
@@ -49,10 +47,7 @@ module Tomo
         return if envs.empty?
         return unless Console.interactive?
 
-        options[:environment] = Console.menu(
-          "Choose an environment:",
-          choices: envs
-        )
+        options[:environment] = Console.menu("Choose an environment:", choices: envs)
       end
     end
   end

--- a/lib/tomo/cli/parser.rb
+++ b/lib/tomo/cli/parser.rb
@@ -46,12 +46,7 @@ module Tomo
       attr_reader :rules, :usage, :after_parse_methods
 
       def evaluate(argv, state, literal:)
-        RulesEvaluator.evaluate(
-          rules: rules.to_a,
-          argv: argv,
-          state: state,
-          literal: literal
-        )
+        RulesEvaluator.evaluate(rules: rules.to_a, argv: argv, state: state, literal: literal)
       end
 
       def check_required_rules(state)

--- a/lib/tomo/cli/project_options.rb
+++ b/lib/tomo/cli/project_options.rb
@@ -3,9 +3,7 @@ module Tomo
     module ProjectOptions
       def self.included(mod)
         mod.class_eval do
-          option :project,
-                 "-c, --config PATH",
-                 "Location of project config (default: #{DEFAULT_CONFIG_PATH})"
+          option :project, "-c, --config PATH", "Location of project config (default: #{DEFAULT_CONFIG_PATH})"
         end
       end
 

--- a/lib/tomo/cli/rules.rb
+++ b/lib/tomo/cli/rules.rb
@@ -51,21 +51,11 @@ module Tomo
       attr_reader :rules
 
       def optional_arg_rule(spec, values_proc)
-        Rules::Argument.new(
-          spec,
-          values_proc: values_proc,
-          required: false,
-          multiple: false
-        )
+        Rules::Argument.new(spec, values_proc: values_proc, required: false, multiple: false)
       end
 
       def required_arg_rule(spec, values_proc)
-        Rules::Argument.new(
-          spec,
-          values_proc: values_proc,
-          required: true,
-          multiple: false
-        )
+        Rules::Argument.new(spec, values_proc: values_proc, required: true, multiple: false)
       end
 
       def mutiple_optional_args_rule(spec, values_proc)
@@ -73,10 +63,7 @@ module Tomo
       end
 
       def on_off_switch_rule(key, name, _values_proc, callback_proc)
-        Rules::Switch.new(key,
-                          "--#{name}",
-                          "--no-#{name}",
-                          callback_proc: callback_proc) do |arg|
+        Rules::Switch.new(key, "--#{name}", "--no-#{name}", callback_proc: callback_proc) do |arg|
           arg == "--#{name}"
         end
       end
@@ -86,12 +73,7 @@ module Tomo
       end
 
       def value_switch_rule(key, *switches, values_proc, callback_proc)
-        Rules::ValueSwitch.new(
-          key,
-          *switches,
-          values_proc: values_proc,
-          callback_proc: callback_proc
-        )
+        Rules::ValueSwitch.new(key, *switches, values_proc: values_proc, callback_proc: callback_proc)
       end
     end
   end

--- a/lib/tomo/cli/rules/switch.rb
+++ b/lib/tomo/cli/rules/switch.rb
@@ -1,10 +1,6 @@
 class Tomo::CLI::Rules
   class Switch
-    def initialize(key,
-                   *switches,
-                   required: false,
-                   callback_proc:,
-                   &convert_proc)
+    def initialize(key, *switches, required: false, callback_proc:, &convert_proc)
       @key = key
       @switches = switches
       @callback_proc = callback_proc

--- a/lib/tomo/cli/rules/value_switch.rb
+++ b/lib/tomo/cli/rules/value_switch.rb
@@ -51,8 +51,7 @@ class Tomo::CLI::Rules
     end
 
     def raise_missing_value(switch)
-      raise Tomo::CLI::Error,
-            "Please specify a value for the #{yellow(switch)} option."
+      raise Tomo::CLI::Error, "Please specify a value for the #{yellow(switch)} option."
     end
   end
 end

--- a/lib/tomo/cli/rules_evaluator.rb
+++ b/lib/tomo/cli/rules_evaluator.rb
@@ -41,11 +41,7 @@ module Tomo
       def complete_if_needed(matched_rules, *matched_args)
         return unless Completions.active?
 
-        completions.print_completions_and_exit(
-          matched_rules,
-          *matched_args,
-          state: state
-        )
+        completions.print_completions_and_exit(matched_rules, *matched_args, state: state)
       end
 
       def remaining_rules
@@ -56,15 +52,9 @@ module Tomo
 
       def raise_unrecognized_args
         problem_arg = argv.first
-        type = if literal || !problem_arg.start_with?("-")
-                 "arg"
-               else
-                 "option"
-               end
+        type = literal || !problem_arg.start_with?("-") ? "arg" : "option"
 
-        raise CLI::Error,
-              "#{Colors.yellow(problem_arg)} is not a recognized #{type} "\
-              "for this tomo command."
+        raise CLI::Error, "#{Colors.yellow(problem_arg)} is not a recognized #{type} for this tomo command."
       end
     end
   end

--- a/lib/tomo/cli/usage.rb
+++ b/lib/tomo/cli/usage.rb
@@ -18,9 +18,7 @@ module Tomo
       end
 
       def to_s
-        indent([
-          "", banner_proc.call, "Options:", "", indent(options_help), "\n"
-        ].join("\n"))
+        indent(["", banner_proc.call, "Options:", "", indent(options_help), "\n"].join("\n"))
       end
 
       private

--- a/lib/tomo/commands/default.rb
+++ b/lib/tomo/commands/default.rb
@@ -42,9 +42,7 @@ module Tomo
         # do anything, so if we got this far, something has gone wrong.
 
         if options.any?
-          raise CLI::Error,
-                "Options must be specified after the command: " +
-                yellow("tomo #{args.first} [options]")
+          raise CLI::Error, "Options must be specified after the command: " + yellow("tomo #{args.first} [options]")
         end
 
         raise_unrecognized_command(args.first)

--- a/lib/tomo/commands/run.rb
+++ b/lib/tomo/commands/run.rb
@@ -3,9 +3,7 @@ module Tomo
     class Run < CLI::Command
       include CLI::DeployOptions
 
-      option :privileged,
-             "--[no-]privileged",
-             "Run the task using a privileged user (e.g. root)"
+      option :privileged, "--[no-]privileged", "Run the task using a privileged user (e.g. root)"
 
       include CLI::ProjectOptions
       include CLI::CommonOptions

--- a/lib/tomo/configuration.rb
+++ b/lib/tomo/configuration.rb
@@ -3,16 +3,13 @@ module Tomo
     autoload :DSL, "tomo/configuration/dsl"
     autoload :Environment, "tomo/configuration/environment"
     autoload :Glob, "tomo/configuration/glob"
-    autoload :PluginFileNotFoundError,
-             "tomo/configuration/plugin_file_not_found_error"
+    autoload :PluginFileNotFoundError, "tomo/configuration/plugin_file_not_found_error"
     autoload :PluginsRegistry, "tomo/configuration/plugins_registry"
     autoload :ProjectNotFoundError, "tomo/configuration/project_not_found_error"
     autoload :RoleBasedTaskFilter, "tomo/configuration/role_based_task_filter"
-    autoload :UnknownEnvironmentError,
-             "tomo/configuration/unknown_environment_error"
+    autoload :UnknownEnvironmentError, "tomo/configuration/unknown_environment_error"
     autoload :UnknownPluginError, "tomo/configuration/unknown_plugin_error"
-    autoload :UnspecifiedEnvironmentError,
-             "tomo/configuration/unspecified_environment_error"
+    autoload :UnspecifiedEnvironmentError, "tomo/configuration/unspecified_environment_error"
 
     def self.from_config_rb(path=DEFAULT_CONFIG_PATH)
       ProjectNotFoundError.raise_with(path: path) unless File.file?(path)
@@ -27,8 +24,7 @@ module Tomo
       raise DSL::ErrorFormatter.decorate(e, path, config_rb&.lines)
     end
 
-    attr_accessor :environments, :deploy_tasks, :setup_tasks, :hosts, :plugins,
-                  :settings, :task_filter, :path
+    attr_accessor :environments, :deploy_tasks, :setup_tasks, :hosts, :plugins, :settings, :task_filter, :path
 
     def initialize
       @environments = {}
@@ -116,9 +112,7 @@ module Tomo
     end
 
     def raise_unknown_environment(environ)
-      UnknownEnvironmentError.raise_with(
-        name: environ, known_environments: environments.keys
-      )
+      UnknownEnvironmentError.raise_with(name: environ, known_environments: environments.keys)
     end
   end
 end

--- a/lib/tomo/configuration/dsl/hosts_and_settings.rb
+++ b/lib/tomo/configuration/dsl/hosts_and_settings.rb
@@ -7,8 +7,7 @@ module Tomo
           self
         end
 
-        def host(address, port: 22, roles: [],
-                 log_prefix: nil, privileged_user: "root")
+        def host(address, port: 22, roles: [], log_prefix: nil, privileged_user: "root")
           @config.hosts << Host.parse(
             address,
             privileged_user: privileged_user,

--- a/lib/tomo/configuration/plugins_registry.rb
+++ b/lib/tomo/configuration/plugins_registry.rb
@@ -1,8 +1,7 @@
 module Tomo
   class Configuration
     class PluginsRegistry
-      autoload :FileResolver,
-               "tomo/configuration/plugins_registry/file_resolver"
+      autoload :FileResolver, "tomo/configuration/plugins_registry/file_resolver"
       autoload :GemResolver, "tomo/configuration/plugins_registry/gem_resolver"
 
       attr_reader :helper_modules, :settings

--- a/lib/tomo/configuration/unknown_environment_error.rb
+++ b/lib/tomo/configuration/unknown_environment_error.rb
@@ -36,10 +36,7 @@ module Tomo
       end
 
       def suggestions
-        @_suggestions ||= Error::Suggestions.new(
-          dictionary: known_environments,
-          word: name
-        )
+        @_suggestions ||= Error::Suggestions.new(dictionary: known_environments, word: name)
       end
     end
   end

--- a/lib/tomo/console.rb
+++ b/lib/tomo/console.rb
@@ -18,10 +18,7 @@ module Tomo
     end
 
     def interactive?
-      input.respond_to?(:raw) &&
-        input.respond_to?(:tty?) &&
-        input.tty? &&
-        !ci?
+      input.respond_to?(:raw) && input.respond_to?(:tty?) && input.tty? && !ci?
     end
 
     def prompt(question)
@@ -66,10 +63,7 @@ module Tomo
     end
 
     def raise_non_interactive
-      NonInteractiveError.raise_with(
-        task: Runtime::Current.task,
-        ci_var: (env.keys & CI_VARS).first
-      )
+      NonInteractiveError.raise_with(task: Runtime::Current.task, ci_var: (env.keys & CI_VARS).first)
     end
   end
 end

--- a/lib/tomo/console/menu.rb
+++ b/lib/tomo/console/menu.rb
@@ -12,8 +12,7 @@ module Tomo
       extend Forwardable
       include Colors
 
-      def initialize(question, options, key_reader: KeyReader.new,
-                     output: $stdout)
+      def initialize(question, options, key_reader: KeyReader.new, output: $stdout)
         @question = question
         @options = options
         @position = 0

--- a/lib/tomo/host.rb
+++ b/lib/tomo/host.rb
@@ -13,8 +13,7 @@ module Tomo
       new(**{ user: user, address: address }.merge(kwargs))
     end
 
-    def initialize(address:, port: nil, log_prefix: nil, roles: nil,
-                   user: nil, privileged_user: "root")
+    def initialize(address:, port: nil, log_prefix: nil, roles: nil, user: nil, privileged_user: "root")
       @user = user.freeze
       @port = (port || 22).to_i.freeze
       @address = address.freeze

--- a/lib/tomo/plugin/bundler/tasks.rb
+++ b/lib/tomo/plugin/bundler/tasks.rb
@@ -30,12 +30,7 @@ module Tomo::Plugin::Bundler
 
     def upgrade_bundler
       needed_bundler_ver = version_setting || extract_bundler_ver_from_lockfile
-
-      remote.run(
-        "gem", "install", "bundler",
-        "--conservative", "--no-document",
-        "-v", needed_bundler_ver
-      )
+      remote.run("gem", "install", "bundler", "--conservative", "--no-document", "-v", needed_bundler_ver)
     end
 
     private

--- a/lib/tomo/plugin/core/tasks.rb
+++ b/lib/tomo/plugin/core/tasks.rb
@@ -34,8 +34,7 @@ module Tomo::Plugin::Core
       remote.run "mv", "-fT", tmp_link, paths.current
     end
 
-    # rubocop:disable Metrics/AbcSize
-    def clean_releases
+    def clean_releases # rubocop:disable Metrics/AbcSize
       desired_count = settings[:keep_releases].to_i
       return if desired_count < 1
 
@@ -49,15 +48,13 @@ module Tomo::Plugin::Core
         remote.rm_rf(*releases.take(releases.length - desired_count))
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     def write_release_json
       json = JSON.pretty_generate(remote.release)
       remote.write(text: "#{json}\n", to: paths.release_json)
     end
 
-    # rubocop:disable Metrics/AbcSize
-    def log_revision
+    def log_revision # rubocop:disable Metrics/AbcSize
       ref = remote.release[:ref]
       revision = remote.release[:revision]
 
@@ -69,7 +66,6 @@ module Tomo::Plugin::Core
 
       remote.write(text: message, to: paths.revision_log, append: true)
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 
@@ -123,12 +119,7 @@ module Tomo::Plugin::Core
     end
 
     def read_current_release
-      result = remote.run(
-        "readlink",
-        paths.current,
-        raise_on_error: false,
-        silent: true
-      )
+      result = remote.run("readlink", paths.current, raise_on_error: false, silent: true)
       return nil if result.failure?
 
       result.stdout.strip[%r{/(#{RELEASE_REGEXP})$}, 1]

--- a/lib/tomo/plugin/env/tasks.rb
+++ b/lib/tomo/plugin/env/tasks.rb
@@ -65,10 +65,7 @@ module Tomo::Plugin::Env
     end
 
     def read_existing
-      remote.capture(
-        "cat", paths.env,
-        raise_on_error: false, echo: false, silent: true
-      )
+      remote.capture("cat", paths.env, raise_on_error: false, echo: false, silent: true)
     end
 
     def replace_entry(text, name, value)

--- a/lib/tomo/plugin/git.rb
+++ b/lib/tomo/plugin/git.rb
@@ -7,14 +7,11 @@ module Tomo::Plugin
 
     helpers Tomo::Plugin::Git::Helpers
     tasks Tomo::Plugin::Git::Tasks
-
-    # rubocop:disable Layout/LineLength
     defaults git_branch:     "master",
              git_repo_path:  "%{deploy_to}/git_repo",
              git_exclusions: [],
              git_env:        { GIT_SSH_COMMAND: "ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no" },
              git_ref:        nil,
              git_url:        nil
-    # rubocop:enable Layout/LineLength
   end
 end

--- a/lib/tomo/plugin/git/tasks.rb
+++ b/lib/tomo/plugin/git/tasks.rb
@@ -3,7 +3,6 @@ require "time"
 
 module Tomo::Plugin::Git
   class Tasks < Tomo::TaskLibrary
-    # rubocop:disable Metrics/AbcSize
     def clone
       require_setting :git_url
 
@@ -15,7 +14,7 @@ module Tomo::Plugin::Git
       end
     end
 
-    def create_release
+    def create_release # rubocop:disable Metrics/AbcSize
       remote.chdir(paths.git_repo) do
         remote.git("remote update --prune")
       end
@@ -31,7 +30,6 @@ module Tomo::Plugin::Git
         )
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 
@@ -64,19 +62,13 @@ module Tomo::Plugin::Git
       exclusions = settings[:git_exclusions] || []
       attributes = exclusions.map { |excl| "#{excl} export-ignore" }.join("\n")
 
-      remote.write(
-        text: attributes,
-        to: paths.git_repo.join("info/attributes")
-      )
+      remote.write(text: attributes, to: paths.git_repo.join("info/attributes"))
     end
 
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
-    def store_release_info
+    def store_release_info # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       log = remote.chdir(paths.git_repo) do
         remote.git(
-          'log -n1 --date=iso --pretty=format:"%H/%cd/%ae" '\
-          "#{ref.shellescape} --",
+          %Q(log -n1 --date=iso --pretty=format:"%H/%cd/%ae" #{ref.shellescape} --),
           silent: true
         ).stdout.strip
       end
@@ -90,7 +82,5 @@ module Tomo::Plugin::Git
       remote.release[:deploy_date] = Time.now.to_s
       remote.release[:deploy_user] = settings.fetch(:local_user)
     end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/lib/tomo/plugin/nodenv/tasks.rb
+++ b/lib/tomo/plugin/nodenv/tasks.rb
@@ -34,9 +34,7 @@ module Tomo::Plugin::Nodenv
       require_setting :nodenv_node_version
       node_version = settings[:nodenv_node_version]
 
-      unless node_installed?(node_version)
-        remote.run "nodenv install #{node_version.shellescape}"
-      end
+      remote.run "nodenv install #{node_version.shellescape}" unless node_installed?(node_version)
       remote.run "nodenv global #{node_version.shellescape}"
     end
 

--- a/lib/tomo/plugin/puma.rb
+++ b/lib/tomo/plugin/puma.rb
@@ -5,8 +5,6 @@ module Tomo::Plugin
     extend Tomo::PluginDSL
 
     tasks Tomo::Plugin::Puma::Tasks
-
-    # rubocop:disable Layout/LineLength
     defaults puma_check_timeout: 15,
              puma_host: "0.0.0.0",
              puma_port: "3000",
@@ -16,6 +14,5 @@ module Tomo::Plugin
              puma_systemd_socket_path: ".config/systemd/user/%{puma_systemd_socket}",
              puma_systemd_service_template_path: File.expand_path("puma/systemd/service.erb", __dir__),
              puma_systemd_socket_template_path: File.expand_path("puma/systemd/socket.erb", __dir__)
-    # rubocop:enable Layout/LineLength
   end
 end

--- a/lib/tomo/plugin/puma/tasks.rb
+++ b/lib/tomo/plugin/puma/tasks.rb
@@ -2,8 +2,7 @@ module Tomo::Plugin::Puma
   class Tasks < Tomo::TaskLibrary
     SystemdUnit = Struct.new(:name, :template, :path)
 
-    # rubocop:disable Metrics/AbcSize
-    def setup_systemd
+    def setup_systemd # rubocop:disable Metrics/AbcSize
       linger_must_be_enabled!
 
       setup_directories
@@ -13,7 +12,6 @@ module Tomo::Plugin::Puma
       remote.run "systemctl --user daemon-reload"
       remote.run "systemctl", "--user", "enable", service.name, socket.name
     end
-    # rubocop:enable Metrics/AbcSize
 
     %i[start stop status].each do |action|
       define_method(action) do
@@ -37,9 +35,7 @@ module Tomo::Plugin::Puma
     end
 
     def log
-      remote.attach "journalctl", "-q",
-                    raw("--user-unit=#{service.name.shellescape}"),
-                    *settings[:run_args]
+      remote.attach "journalctl", "-q", raw("--user-unit=#{service.name.shellescape}"), *settings[:run_args]
     end
 
     private
@@ -102,22 +98,17 @@ module Tomo::Plugin::Puma
     end
 
     def assert_active!
-      return true if remote.run? "systemctl", "--user", "is-active",
-                                 service.name,
-                                 silent: true, raise_on_error: false
+      return true if remote.run? "systemctl", "--user", "is-active", service.name, silent: true, raise_on_error: false
 
-      remote.run "systemctl", "--user", "status", service.name,
-                 raise_on_error: false
-      remote.run "journalctl -q -n 50 --user-unit=#{service.name.shellescape}",
-                 raise_on_error: false
+      remote.run "systemctl", "--user", "status", service.name, raise_on_error: false
+      remote.run "journalctl -q -n 50 --user-unit=#{service.name.shellescape}", raise_on_error: false
 
       die "puma failed to start (see previous systemctl and journalctl output)"
     end
 
     def listening?
       test_url = "http://localhost:#{port}"
-      remote.run? "curl -sS --connect-timeout 1 --max-time 10 #{test_url}"\
-                  " > /dev/null"
+      remote.run? "curl -sS --connect-timeout 1 --max-time 10 #{test_url} > /dev/null"
     end
   end
 end

--- a/lib/tomo/plugin/rails/tasks.rb
+++ b/lib/tomo/plugin/rails/tasks.rb
@@ -40,11 +40,9 @@ module Tomo::Plugin::Rails
 
     def db_structure_load
       if !structure_sql_present?
-        logger.warn "db/structure.sql is not present; "\
-                    "skipping db:structure:load."
+        logger.warn "db/structure.sql is not present; skipping db:structure:load."
       elsif database_schema_loaded?
-        logger.info "Database structure already loaded; "\
-                    "skipping db:structure:load."
+        logger.info "Database structure already loaded; skipping db:structure:load."
       else
         remote.rake("db:structure:load")
       end

--- a/lib/tomo/plugin/testing.rb
+++ b/lib/tomo/plugin/testing.rb
@@ -1,6 +1,4 @@
-unless defined?(Tomo::Testing)
-  raise "The testing plugin cannot be used outside of unit tests"
-end
+raise "The testing plugin cannot be used outside of unit tests" unless defined?(Tomo::Testing)
 
 module Tomo::Plugin
   class Testing < Tomo::TaskLibrary

--- a/lib/tomo/remote.rb
+++ b/lib/tomo/remote.rb
@@ -21,9 +21,7 @@ module Tomo
 
     def attach(*command, default_chdir: nil, **command_opts)
       full_command = shell_builder.build(*command, default_chdir: default_chdir)
-      ssh.ssh_exec(
-        Script.new(full_command, **{ pty: true }.merge(command_opts))
-      )
+      ssh.ssh_exec(Script.new(full_command, **{ pty: true }.merge(command_opts)))
     end
 
     def run(*command, attach: false, default_chdir: nil, **command_opts)

--- a/lib/tomo/runtime.rb
+++ b/lib/tomo/runtime.rb
@@ -3,8 +3,7 @@ require "time"
 module Tomo
   class Runtime
     autoload :ConcurrentRubyLoadError, "tomo/runtime/concurrent_ruby_load_error"
-    autoload :ConcurrentRubyThreadPool,
-             "tomo/runtime/concurrent_ruby_thread_pool"
+    autoload :ConcurrentRubyThreadPool, "tomo/runtime/concurrent_ruby_thread_pool"
     autoload :Context, "tomo/runtime/context"
     autoload :Current, "tomo/runtime/current"
     autoload :ExecutionPlan, "tomo/runtime/execution_plan"
@@ -28,8 +27,7 @@ module Tomo
 
     attr_reader :tasks
 
-    def initialize(deploy_tasks:, setup_tasks:, hosts:, task_filter:,
-                   settings:, plugins_registry:)
+    def initialize(deploy_tasks:, setup_tasks:, hosts:, task_filter:, settings:, plugins_registry:)
       @deploy_tasks = deploy_tasks.freeze
       @setup_tasks = setup_tasks.freeze
       @hosts = hosts.freeze
@@ -68,8 +66,7 @@ module Tomo
 
     private
 
-    attr_reader :deploy_tasks, :setup_tasks, :hosts, :task_filter, :settings,
-                :plugins_registry
+    attr_reader :deploy_tasks, :setup_tasks, :hosts, :task_filter, :settings, :plugins_registry
 
     def new_task_runner(release_type, args)
       run_settings = { release_path: release_path_for(release_type) }

--- a/lib/tomo/runtime/concurrent_ruby_thread_pool.rb
+++ b/lib/tomo/runtime/concurrent_ruby_thread_pool.rb
@@ -4,10 +4,7 @@ begin
   gem "concurrent-ruby", concurrent_ver
   require "concurrent"
 rescue LoadError => e
-  Tomo::Runtime::ConcurrentRubyLoadError.raise_with(
-    e.message,
-    version: concurrent_ver
-  )
+  Tomo::Runtime::ConcurrentRubyLoadError.raise_with(e.message, version: concurrent_ver)
 end
 
 module Tomo

--- a/lib/tomo/runtime/execution_plan.rb
+++ b/lib/tomo/runtime/execution_plan.rb
@@ -77,10 +77,7 @@ module Tomo
       def build_plan(tasks, task_filter)
         tasks.each_with_object([]) do |task, result|
           steps = hosts.map do |host|
-            HostExecutionStep.new(
-              tasks: task, host: host,
-              task_filter: task_filter, task_runner: task_runner
-            )
+            HostExecutionStep.new(tasks: task, host: host, task_filter: task_filter, task_runner: task_runner)
           end
           steps.reject!(&:empty?)
           result << steps unless steps.empty?

--- a/lib/tomo/runtime/explanation.rb
+++ b/lib/tomo/runtime/explanation.rb
@@ -7,10 +7,7 @@ module Tomo
         @concurrency = concurrency
       end
 
-      # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/CyclomaticComplexity
-      def to_s
+      def to_s # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
         desc = []
         threads = [applicable_hosts.length, concurrency].min
         desc << "CONCURRENTLY (#{threads} THREADS):" if threads > 1
@@ -32,9 +29,6 @@ module Tomo
         end
         desc.join("\n")
       end
-      # rubocop:enable Metrics/MethodLength
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/CyclomaticComplexity
 
       private
 

--- a/lib/tomo/runtime/settings_required_error.rb
+++ b/lib/tomo/runtime/settings_required_error.rb
@@ -21,9 +21,7 @@ module Tomo
       private
 
       def settings_sentence
-        if settings.length == 1
-          return "a value for the #{yellow(settings.first.to_s)} setting."
-        end
+        return "a value for the #{yellow(settings.first.to_s)} setting." if settings.length == 1
 
         sentence = "values for these settings:\n\n  "
         sentence << settings.map { |s| yellow(s.to_s) }.join("\n  ")

--- a/lib/tomo/runtime/task_runner.rb
+++ b/lib/tomo/runtime/task_runner.rb
@@ -19,11 +19,7 @@ module Tomo
       def validate_task!(name)
         return if tasks_by_name.key?(name)
 
-        UnknownTaskError.raise_with(
-          name,
-          unknown_task: name,
-          known_tasks: tasks_by_name.keys
-        )
+        UnknownTaskError.raise_with(name, unknown_task: name, known_tasks: tasks_by_name.keys)
       end
 
       def run(task:, remote:)

--- a/lib/tomo/runtime/unknown_task_error.rb
+++ b/lib/tomo/runtime/unknown_task_error.rb
@@ -17,10 +17,7 @@ module Tomo
       private
 
       def spelling_suggestion
-        sugg = Error::Suggestions.new(
-          dictionary: known_tasks,
-          word: unknown_task
-        )
+        sugg = Error::Suggestions.new(dictionary: known_tasks, word: unknown_task)
         sugg.to_console if sugg.any?
       end
 

--- a/lib/tomo/script.rb
+++ b/lib/tomo/script.rb
@@ -2,11 +2,7 @@ module Tomo
   class Script
     attr_reader :script
 
-    def initialize(script,
-                   echo: true,
-                   pty: false,
-                   raise_on_error: true,
-                   silent: false)
+    def initialize(script, echo: true, pty: false, raise_on_error: true, silent: false)
       @script = script
       @echo = echo
       @pty = pty

--- a/lib/tomo/shell_builder.rb
+++ b/lib/tomo/shell_builder.rb
@@ -45,9 +45,7 @@ module Tomo
     end
 
     def build(*command, default_chdir: nil)
-      if @chdir.empty? && default_chdir
-        return chdir(default_chdir) { build(*command) }
-      end
+      return chdir(default_chdir) { build(*command) } if @chdir.empty? && default_chdir
 
       command_string = command_to_string(*command)
       modifiers = [cd_chdir, unset_env, export_env, set_umask].compact.flatten
@@ -97,11 +95,7 @@ module Tomo
     def set_umask
       return if @umask.nil?
 
-      umask_value = if @umask.is_a?(Integer)
-                      @umask.to_s(8).rjust(4, "0")
-                    else
-                      @umask
-                    end
+      umask_value = @umask.is_a?(Integer) ? @umask.to_s(8).rjust(4, "0") : @umask
       "umask #{umask_value.to_s.shellescape}"
     end
   end

--- a/lib/tomo/ssh/child_process.rb
+++ b/lib/tomo/ssh/child_process.rb
@@ -30,17 +30,12 @@ module Tomo
       end
 
       def result
-        Result.new(
-          exit_status: exit_status,
-          stdout: stdout_buffer.string,
-          stderr: stderr_buffer.string
-        )
+        Result.new(exit_status: exit_status, stdout: stdout_buffer.string, stderr: stderr_buffer.string)
       end
 
       private
 
-      attr_reader :command, :exit_status, :on_data,
-                  :stdout_buffer, :stderr_buffer
+      attr_reader :command, :exit_status, :on_data, :stdout_buffer, :stderr_buffer
 
       def start_io_thread(source, buffer)
         new_thread_inheriting_current_vars do

--- a/lib/tomo/ssh/connection.rb
+++ b/lib/tomo/ssh/connection.rb
@@ -6,12 +6,7 @@ module Tomo
   module SSH
     class Connection
       def self.dry_run(host, options)
-        new(
-          host,
-          options,
-          exec_proc: proc { CLI.exit },
-          child_proc: proc { Result.empty_success }
-        )
+        new(host, options, exec_proc: proc { CLI.exit }, child_proc: proc { Result.empty_success })
       end
 
       attr_reader :host
@@ -38,9 +33,7 @@ module Tomo
         result = child_proc.call(*ssh_args, on_data: handle_data)
         logger.script_end(script, result)
 
-        if result.failure? && script.raise_on_error?
-          raise_run_error(script, ssh_args, result)
-        end
+        raise_run_error(script, ssh_args, result) if result.failure? && script.raise_on_error?
 
         result
       end
@@ -69,13 +62,7 @@ module Tomo
       end
 
       def raise_run_error(script, ssh_args, result)
-        ScriptError.raise_with(
-          result.output,
-          host: host,
-          result: result,
-          script: script,
-          ssh_args: ssh_args
-        )
+        ScriptError.raise_with(result.output, host: host, result: result, script: script, ssh_args: ssh_args)
       end
     end
   end

--- a/lib/tomo/ssh/connection_validator.rb
+++ b/lib/tomo/ssh/connection_validator.rb
@@ -27,10 +27,7 @@ module Tomo
       end
 
       def assert_valid_connection!
-        script = Script.new(
-          "echo hi",
-          silent: !Tomo.debug?, echo: false, raise_on_error: false
-        )
+        script = Script.new("echo hi", silent: !Tomo.debug?, echo: false, raise_on_error: false)
         res = connection.ssh_subprocess(script, verbose: Tomo.debug?)
         raise_connection_failure(res) if res.exit_status == 255
         raise_unknown_error(res) if res.failure? || res.stdout.chomp != "hi"

--- a/lib/tomo/ssh/executable_error.rb
+++ b/lib/tomo/ssh/executable_error.rb
@@ -7,8 +7,7 @@ module Tomo
         hint = if executable.to_s.include?("/")
                  "Is the ssh binary properly installed in this location?"
                else
-                 "Is #{yellow(executable)} installed and in your "\
-                 "#{blue('$PATH')}?"
+                 "Is #{yellow(executable)} installed and in your #{blue('$PATH')}?"
                end
 
         <<~ERROR

--- a/lib/tomo/ssh/options.rb
+++ b/lib/tomo/ssh/options.rb
@@ -20,8 +20,7 @@ module Tomo
         freeze
       end
 
-      # rubocop:disable Metrics/AbcSize
-      def build_args(host, script, control_path, verbose)
+      def build_args(host, script, control_path, verbose) # rubocop:disable Metrics/AbcSize
         args = [verbose ? "-v" : ["-o", "LogLevel=ERROR"]]
         args << "-A" if forward_agent
         args << connect_timeout_option
@@ -34,13 +33,11 @@ module Tomo
 
         [executable, args, script.to_s].flatten
       end
-      # rubocop:enable Metrics/AbcSize
 
       private
 
       attr_writer :executable
-      attr_accessor :connect_timeout, :extra_opts, :forward_agent,
-                    :reuse_connections, :strict_host_key_checking
+      attr_accessor :connect_timeout, :extra_opts, :forward_agent, :reuse_connections, :strict_host_key_checking
 
       def control_opts(path, verbose)
         opts = [

--- a/lib/tomo/task_api.rb
+++ b/lib/tomo/task_api.rb
@@ -9,11 +9,7 @@ module Tomo
     def_delegators :context, :paths, :settings
 
     def die(reason)
-      Runtime::TaskAbortedError.raise_with(
-        reason,
-        task: context.current_task,
-        host: remote.host
-      )
+      Runtime::TaskAbortedError.raise_with(reason, task: context.current_task, host: remote.host)
     end
 
     def dry_run?
@@ -26,13 +22,9 @@ module Tomo
 
     def merge_template(path)
       working_path = paths.tomo_config_file&.dirname
-      if working_path && path.start_with?(".")
-        path = File.expand_path(path, working_path)
-      end
+      path = File.expand_path(path, working_path) if working_path && path.start_with?(".")
 
-      unless File.file?(path)
-        Runtime::TemplateNotFoundError.raise_with(path: path)
-      end
+      Runtime::TemplateNotFoundError.raise_with(path: path) unless File.file?(path)
       template = IO.read(path)
       ERB.new(template).result(binding)
     end
@@ -49,10 +41,7 @@ module Tomo
       missing = names.flatten.select { |sett| settings[sett].nil? }
       return if missing.empty?
 
-      Runtime::SettingsRequiredError.raise_with(
-        settings: missing,
-        task: context.current_task
-      )
+      Runtime::SettingsRequiredError.raise_with(settings: missing, task: context.current_task)
     end
     alias require_settings require_setting
   end

--- a/lib/tomo/testing/connection.rb
+++ b/lib/tomo/testing/connection.rb
@@ -2,12 +2,7 @@ module Tomo
   module Testing
     class Connection < Tomo::SSH::Connection
       def initialize(host, options)
-        super(
-          host,
-          options,
-          exec_proc: proc { raise MockedExecError },
-          child_proc: method(:mock_child_process)
-        )
+        super(host, options, exec_proc: proc { raise MockedExecError }, child_proc: method(:mock_child_process))
       end
 
       def ssh_exec(script)

--- a/lib/tomo/testing/docker_image.rb
+++ b/lib/tomo/testing/docker_image.rb
@@ -74,14 +74,8 @@ module Tomo
       end
 
       def set_up_private_key
-        @private_key_path = File.join(
-          Dir.tmpdir,
-          "tomo_test_ed25519_#{SecureRandom.hex(8)}"
-        )
-        FileUtils.cp(
-          File.expand_path("tomo_test_ed25519", __dir__),
-          private_key_path
-        )
+        @private_key_path = File.join(Dir.tmpdir, "tomo_test_ed25519_#{SecureRandom.hex(8)}")
+        FileUtils.cp(File.expand_path("tomo_test_ed25519", __dir__), private_key_path)
         FileUtils.chmod(0o600, private_key_path)
       end
 

--- a/lib/tomo/testing/local.rb
+++ b/lib/tomo/testing/local.rb
@@ -41,9 +41,7 @@ module Tomo
           progress(command_str) do
             output, status = Open3.capture2e(*command)
 
-            if raise_on_error && !status.success?
-              raise "Command failed: #{command_str}\n#{output}"
-            end
+            raise "Command failed: #{command_str}\n#{output}" if raise_on_error && !status.success?
 
             output
           end

--- a/lib/tomo/testing/ubuntu_setup.sh
+++ b/lib/tomo/testing/ubuntu_setup.sh
@@ -17,8 +17,7 @@ touch /var/lib/systemd/linger/deployer
 
 # Packages needed for ruby, etc.
 apt-get -y update
-apt-get -y install build-essential zlib1g-dev libssl-dev libreadline-dev \
-                   git-core curl locales libsqlite3-dev
+apt-get -y install build-essential zlib1g-dev libssl-dev libreadline-dev git-core curl locales libsqlite3-dev
 
 apt-get -y install tzdata \
         -o DPkg::options::="--force-confdef" \

--- a/test/rails_setup_deploy_e2e_test.rb
+++ b/test/rails_setup_deploy_e2e_test.rb
@@ -21,8 +21,7 @@ class RailsSetupDeployE2ETest < Minitest::Test
       config = IO.read(".tomo/config.rb")
       config.sub!(
         /host ".*"/,
-        %Q(host "#{@docker.host.user}@#{@docker.host.address}", )\
-        "port: #{@docker.host.port}"
+        %Q(host "#{@docker.host.user}@#{@docker.host.address}", port: #{@docker.host.port})
       )
       config << <<~CONFIG
         set(#{@docker.ssh_settings.inspect})

--- a/test/support/reporters.rb
+++ b/test/support/reporters.rb
@@ -1,7 +1,2 @@
 require "minitest/reporters"
-
-Minitest::Reporters.use!(
-  Minitest::Reporters::SpecReporter.new,
-  ENV,
-  Minitest.backtrace_filter
-)
+Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new, ENV, Minitest.backtrace_filter)

--- a/test/tomo/host_test.rb
+++ b/test/tomo/host_test.rb
@@ -29,12 +29,7 @@ class Tomo::HostTest < Minitest::Test
   end
 
   def test_parse_with_options
-    host = Tomo::Host.parse(
-      "deployer@app.example.com",
-      port: 8022,
-      log_prefix: "one",
-      roles: %w[db web]
-    )
+    host = Tomo::Host.parse("deployer@app.example.com", port: 8022, log_prefix: "one", roles: %w[db web])
     assert_equal("app.example.com", host.address)
     assert_equal(8022, host.port)
     assert_equal("deployer", host.user)

--- a/test/tomo/plugin/bundler/tasks_test.rb
+++ b/test/tomo/plugin/bundler/tasks_test.rb
@@ -75,19 +75,13 @@ class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
          2.0.2
     OUT
     tester.run_task("bundler:upgrade_bundler")
-    assert_equal(
-      "gem install bundler --conservative --no-document -v 2.0.2",
-      tester.executed_scripts.last
-    )
+    assert_equal("gem install bundler --conservative --no-document -v 2.0.2", tester.executed_scripts.last)
   end
 
   def test_upgrade_bundler_uses_setting_for_version
     tester = configure(bundler_version: "2.0.1")
     tester.run_task("bundler:upgrade_bundler")
-    assert_equal(
-      "gem install bundler --conservative --no-document -v 2.0.1",
-      tester.executed_script
-    )
+    assert_equal("gem install bundler --conservative --no-document -v 2.0.1", tester.executed_script)
   end
 
   def test_upgrade_bundler_dies_if_lock_file_is_absent_and_no_version_specified

--- a/test/tomo/plugin/core/helpers_test.rb
+++ b/test/tomo/plugin/core/helpers_test.rb
@@ -85,10 +85,7 @@ class Tomo::Plugin::Core::HelpersTest < Minitest::Test
 
   def test_mkdir_p
     @tester.call_helper(:mkdir_p, "/a/path", "/another/file name")
-    assert_equal(
-      'mkdir -p /a/path /another/file\ name',
-      @tester.executed_script
-    )
+    assert_equal('mkdir -p /a/path /another/file\ name', @tester.executed_script)
   end
 
   def test_rm_rf

--- a/test/tomo/plugin/core/tasks_test.rb
+++ b/test/tomo/plugin/core/tasks_test.rb
@@ -11,9 +11,7 @@ class Tomo::Plugin::Core::TasksTest < Minitest::Test
   def test_setup_directories
     @tester.run_task("core:setup_directories")
     assert_equal(
-      "mkdir -p /var/www/testing "\
-               "/var/www/testing/releases "\
-               "/var/www/testing/shared",
+      "mkdir -p /var/www/testing /var/www/testing/releases /var/www/testing/shared",
       @tester.executed_script
     )
   end
@@ -29,10 +27,8 @@ class Tomo::Plugin::Core::TasksTest < Minitest::Test
     @tester.run_task("core:symlink_shared")
     assert_equal(
       [
-        "mkdir -p /var/www/testing/shared/config "\
-                 "/var/www/testing/current/config",
-        "ln -sfn /var/www/testing/shared/config/database.yml "\
-                "/var/www/testing/current/config/database.yml",
+        "mkdir -p /var/www/testing/shared/config /var/www/testing/current/config",
+        "ln -sfn /var/www/testing/shared/config/database.yml /var/www/testing/current/config/database.yml",
         "ln -sfn /var/www/testing/shared/.env /var/www/testing/current/.env"
       ],
       @tester.executed_scripts
@@ -48,10 +44,8 @@ class Tomo::Plugin::Core::TasksTest < Minitest::Test
                  "/var/www/testing/shared/public/assets " \
                  "/var/www/testing/current/public",
         "cd /var/www/testing/current && rm -rf .bundle public/assets",
-        "ln -sf /var/www/testing/shared/.bundle "\
-               "/var/www/testing/current/.bundle",
-        "ln -sf /var/www/testing/shared/public/assets "\
-               "/var/www/testing/current/public/assets"
+        "ln -sf /var/www/testing/shared/.bundle /var/www/testing/current/.bundle",
+        "ln -sf /var/www/testing/shared/public/assets /var/www/testing/current/public/assets"
       ],
       @tester.executed_scripts
     )
@@ -165,10 +159,7 @@ class Tomo::Plugin::Core::TasksTest < Minitest::Test
         "revision": "65eda21"
       }
     JSON
-    assert_equal(
-      "echo -n #{expected.shellescape} > /app/release.json",
-      @tester.executed_script
-    )
+    assert_equal("echo -n #{expected.shellescape} > /app/release.json", @tester.executed_script)
   end
 
   def test_log_revision
@@ -186,10 +177,7 @@ class Tomo::Plugin::Core::TasksTest < Minitest::Test
     )
     @tester.run_task("core:log_revision")
     expected = "#{now} - 65eda21 (master) deployed by matt\n"
-    assert_equal(
-      "echo -n #{expected.shellescape} >> /app/revision.log",
-      @tester.executed_script
-    )
+    assert_equal("echo -n #{expected.shellescape} >> /app/revision.log", @tester.executed_script)
   end
 
   private

--- a/test/tomo/plugin/puma/tasks_test.rb
+++ b/test/tomo/plugin/puma/tasks_test.rb
@@ -13,10 +13,7 @@ class Tomo::Plugin::Puma::TasksTest < Minitest::Test
   end
 
   def test_setup_systemd
-    @tester.mock_script_result(
-      "ls -A1 /var/lib/systemd/linger",
-      stdout: "testing\n"
-    )
+    @tester.mock_script_result("ls -A1 /var/lib/systemd/linger", stdout: "testing\n")
     expected_scripts = [
       "ls -A1 /var/lib/systemd/linger",
       "mkdir -p .config/systemd/user",
@@ -33,10 +30,7 @@ class Tomo::Plugin::Puma::TasksTest < Minitest::Test
   end
 
   def test_setup_systemd_dies_if_linger_is_disabled
-    @tester.mock_script_result(
-      "ls -A1 /var/lib/systemd/linger",
-      stdout: "some_other_user\n"
-    )
+    @tester.mock_script_result("ls -A1 /var/lib/systemd/linger", stdout: "some_other_user\n")
     error = assert_raises(Tomo::Runtime::TaskAbortedError) do
       @tester.run_task("puma:setup_systemd")
     end
@@ -45,26 +39,17 @@ class Tomo::Plugin::Puma::TasksTest < Minitest::Test
 
   def test_start
     @tester.run_task("puma:start")
-    assert_equal(
-      "systemctl --user start puma_test.socket puma_test.service",
-      @tester.executed_script
-    )
+    assert_equal("systemctl --user start puma_test.socket puma_test.service", @tester.executed_script)
   end
 
   def test_stop
     @tester.run_task("puma:stop")
-    assert_equal(
-      "systemctl --user stop puma_test.socket puma_test.service",
-      @tester.executed_script
-    )
+    assert_equal("systemctl --user stop puma_test.socket puma_test.service", @tester.executed_script)
   end
 
   def test_status
     @tester.run_task("puma:status")
-    assert_equal(
-      "systemctl --user status puma_test.socket puma_test.service",
-      @tester.executed_script
-    )
+    assert_equal("systemctl --user status puma_test.socket puma_test.service", @tester.executed_script)
   end
 
   def test_restart
@@ -79,10 +64,7 @@ class Tomo::Plugin::Puma::TasksTest < Minitest::Test
   end
 
   def test_check_active_shows_logs_and_dies_if_serivce_is_inactive
-    @tester.mock_script_result(
-      "systemctl --user is-active puma_test.service",
-      exit_status: 1
-    )
+    @tester.mock_script_result("systemctl --user is-active puma_test.service", exit_status: 1)
     error = assert_raises(Tomo::Runtime::TaskAbortedError) do
       @tester.run_task("puma:check_active")
     end

--- a/test/tomo/plugin/rails/helpers_test.rb
+++ b/test/tomo/plugin/rails/helpers_test.rb
@@ -3,13 +3,8 @@ require "tomo/plugin/rails"
 
 class Tomo::Plugin::Rails::HelpersTest < Minitest::Test
   def test_rake_runs_bundle_exec_rake_in_current_path
-    tester = Tomo::Testing::MockPluginTester.new(
-      "bundler", "rails", settings: { current_path: "/app/current" }
-    )
+    tester = Tomo::Testing::MockPluginTester.new("bundler", "rails", settings: { current_path: "/app/current" })
     tester.call_helper(:rake, "db:migrate")
-    assert_equal(
-      "cd /app/current && bundle exec rake db:migrate",
-      tester.executed_script
-    )
+    assert_equal("cd /app/current && bundle exec rake db:migrate", tester.executed_script)
   end
 end

--- a/test/tomo/runtime/settings_interpolation_test.rb
+++ b/test/tomo/runtime/settings_interpolation_test.rb
@@ -33,11 +33,7 @@ class Tomo::Runtime::SettingsInterpolationTest < Minitest::Test
         current_path: "%{deploy_to}/current"
       )
     end
-    assert_match(
-      "Circular dependency detected in settings: "\
-      "deploy_to -> current_path -> deploy_to",
-      exception.message
-    )
+    assert_match("Circular dependency detected in settings: deploy_to -> current_path -> deploy_to", exception.message)
   end
 
   def test_no_longer_supports_old_syntax
@@ -45,10 +41,7 @@ class Tomo::Runtime::SettingsInterpolationTest < Minitest::Test
       application: "default",
       deploy_to: "/var/www/%<application>"
     )
-    assert_equal(
-      { application: "default", deploy_to: "/var/www/%<application>" },
-      interpolated
-    )
+    assert_equal({ application: "default", deploy_to: "/var/www/%<application>" }, interpolated)
   end
 
   private

--- a/test/tomo/task_api_test.rb
+++ b/test/tomo/task_api_test.rb
@@ -14,10 +14,7 @@ class Tomo::TaskAPITest < Minitest::Test
   def test_merge_template_with_path_relative_to_config
     config_path = File.expand_path("../../.tomo/config.rb", __dir__)
     rel_path = "../test/fixtures/template.erb"
-    subject = configure(
-      application: "test-app",
-      tomo_config_file_path: config_path
-    )
+    subject = configure(application: "test-app", tomo_config_file_path: config_path)
     merged = subject.send(:merge_template, rel_path)
     assert_equal("Hello, test-app!\n", merged)
   end

--- a/tomo.gemspec
+++ b/tomo.gemspec
@@ -9,13 +9,10 @@ Gem::Specification.new do |spec|
   spec.email         = ["opensource@mattbrictson.com"]
 
   spec.summary       = "A friendly CLI for deploying Rails apps ✨"
-  spec.description   = "Tomo is a feature-rich deployment tool that contains "\
-                       "everything you need to deploy a basic Rails app out "\
-                       "of the box. It has an opinionated, production-tested "\
-                       "set of defaults, but is easily extensible via a well-"\
-                       "documented plugin system. Unlike other Ruby-based "\
-                       "deployment tools, tomo’s friendly command-line "\
-                       "interface and task system do not rely on Rake."
+  spec.description   = "Tomo is a feature-rich deployment tool that contains everything you need to deploy a basic "\
+                       "Rails app out of the box. It has an opinionated, production-tested set of defaults, but is "\
+                       "easily extensible via a well-documented plugin system. Unlike other Ruby-based deployment "\
+                       "tools, tomo’s friendly command-line interface and task system do not rely on Rake."
   spec.homepage      = "https://github.com/mattbrictson/tomo"
   spec.license       = "MIT"
 


### PR DESCRIPTION
The rubocop community has decided to standardize on 120 characters for default line length.

https://github.com/rubocop-hq/rubocop/pull/7952

Update rubocop config and reformat ruby files to embrace this convention.