### PR TITLE
Fix TypeError when using raw helper with a frozen string

### DIFF
--- a/lib/tomo/shell_builder.rb
+++ b/lib/tomo/shell_builder.rb
@@ -3,8 +3,9 @@ require "shellwords"
 module Tomo
   class ShellBuilder
     def self.raw(string)
-      string.define_singleton_method(:shellescape) { string }
-      string
+      string.dup.tap do |raw_string|
+        raw_string.define_singleton_method(:shellescape) { string }
+      end
     end
 
     def initialize

--- a/test/tomo/shell_builder_test.rb
+++ b/test/tomo/shell_builder_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Tomo::ShellBuilderTest < Minitest::Test
+  def test_raw_preserves_string_when_shellescaped
+    raw_string = Tomo::ShellBuilder.raw("$HOME")
+    assert_equal("$HOME", raw_string.shellescape)
+  end
+
+  def test_raw_works_with_frozen_strings
+    raw_string = Tomo::ShellBuilder.raw("$HOME".freeze)
+    assert_equal("$HOME", raw_string.shellescape)
+  end
+end


### PR DESCRIPTION
Before, if `raw` was passed a frozen string it would raise an exception:

```
TypeError (can't define singleton)
```

This commit fixes the problem by making a copy of the original string before attempting to extend it.