### PR TITLE
Fix error that would cause dry-run of `bundler:upgrade_bundler` to fail

### DIFF
--- a/lib/tomo/plugin/bundler/tasks.rb
+++ b/lib/tomo/plugin/bundler/tasks.rb
@@ -56,7 +56,7 @@ module Tomo::Plugin::Bundler
         raise_on_error: false
       )
       version = lockfile_tail[/BUNDLED WITH\n   (\S+)$/, 1]
-      return version if version
+      return version if version || dry_run?
 
       die <<~REASON
         Could not guess bundler version from Gemfile.lock.


### PR DESCRIPTION
Before, running a setup with `--dry-run` would fail with this error:

```
* • bundler:upgrade_bundler
* tail -n 10 /tmp/tomo/20200706205321/Gemfile.lock

  ERROR: The bundler:upgrade_bundler task failed on user@hostname.or.ip.address.

  Could not guess bundler version from Gemfile.lock.
  Use the :bundler_version setting to specify the version of bundler to install.
```

This commit allows the dry-run to succeed even if `bundler_version` is not explicitly set.