### PR TITLE
Auto-disable `Style/FormatStringToken` rule in `.tomo/config.rb` if rubocop is present

### DIFF
--- a/lib/tomo/commands/init.rb
+++ b/lib/tomo/commands/init.rb
@@ -94,10 +94,21 @@ module Tomo
         File.exist?(".rubocop.yml")
       end
 
+      def erb_2_2_or_later?
+        erb_version = Gem::Version.new(ERB.version[/\d[\d.]+/])
+        Gem::Requirement.new(">= 2.2").satisfied_by?(erb_version)
+      end
+
       def config_rb_template(app)
         path = File.expand_path("../templates/config.rb.erb", __dir__)
         template = IO.read(path)
-        ERB.new(template, trim_mode: "-").result(binding)
+
+        # TODO: remove once we drop Ruby 2.5 support?
+        if erb_2_2_or_later?
+          ERB.new(template, trim_mode: "-").result(binding)
+        else
+          ERB.new(template, nil, "-").result(binding)
+        end
       end
     end
   end

--- a/lib/tomo/commands/init.rb
+++ b/lib/tomo/commands/init.rb
@@ -90,10 +90,14 @@ module Tomo
         nil
       end
 
+      def rubocop?
+        File.exist?(".rubocop.yml")
+      end
+
       def config_rb_template(app)
         path = File.expand_path("../templates/config.rb.erb", __dir__)
         template = IO.read(path)
-        ERB.new(template).result(binding)
+        ERB.new(template, trim_mode: "-").result(binding)
       end
     end
   end

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -1,3 +1,6 @@
+<% if rubocop? -%>
+# rubocop:disable Style/FormatStringToken
+<% end -%>
 plugin "git"
 plugin "env"
 plugin "bundler"
@@ -72,3 +75,6 @@ deploy do
   run "bundler:clean"
   run "core:log_revision"
 end
+<% if rubocop? -%>
+# rubocop:enable Style/FormatStringToken
+<% end -%>


### PR DESCRIPTION
Tomo relies on `%{...}` syntax for interpolating settings. However, the default configuration for rubocop flags this syntax as a problem and suggests an alternative that doesn't work with tomo.

To prevent confusion, `tomo init` will now automatically include a special comment to disable the `Style/FormatStringToken` rule if it detects that rubocop is present.