### PR TITLE
Prevent multiple apps from sharing the same bashrc

### DIFF
--- a/test/tomo/plugin/env/tasks_test.rb
+++ b/test/tomo/plugin/env/tasks_test.rb
@@ -14,10 +14,69 @@ class Tomo::Plugin::Env::TasksTest < Minitest::Test
       }
     )
     tester.run_task("env:setup")
-    assert_equal(<<~'EXPECTED'.strip, tester.executed_scripts[2])
+    assert_equal(<<~'EXPECTED'.strip, tester.executed_scripts[4])
       echo -n export\ RAILS_MAX_THREADS\=6'
       'export\ RAILS_ENV\=production'
       ' > /app/envrc
     EXPECTED
+  end
+
+  def test_setup_does_not_modify_bashrc_if_it_is_already_set_up
+    tester = Tomo::Testing::MockPluginTester.new(
+      "env",
+      settings: {
+        bashrc_path: ".bashrc",
+        env_path: "/app/envrc"
+      }
+    )
+
+    tester.mock_script_result("cat .bashrc", stdout: <<~STDOUT)
+      if [ -f /app/envrc ]; then  # DO NOT MODIFY THESE LINES
+        . /app/envrc              # ENV MAINTAINED BY TOMO
+      fi                          # END TOMO ENV
+
+      # ~/.bashrc: executed by bash(1) for non-login shells.
+      # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+      # for examples
+
+      # If not running interactively, don't do anything
+      case $- in
+          *i*) ;;
+            *) return;;
+      esac
+    STDOUT
+
+    tester.run_task("env:setup")
+    assert_empty(tester.executed_scripts.grep(/> .bashrc/))
+  end
+
+  def test_setup_fails_if_wrong_envrc_already_exists_in_bashrc
+    tester = Tomo::Testing::MockPluginTester.new(
+      "env",
+      settings: {
+        bashrc_path: ".bashrc",
+        env_path: "/var/www/newapp/envrc"
+      }
+    )
+
+    tester.mock_script_result("cat .bashrc", stdout: <<~STDOUT)
+      if [ -f /var/www/oldapp/envrc ]; then  # DO NOT MODIFY THESE LINES
+        . /var/www/oldapp/envrc              # ENV MAINTAINED BY TOMO
+      fi                                     # END TOMO ENV
+
+      # ~/.bashrc: executed by bash(1) for non-login shells.
+      # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+      # for examples
+
+      # If not running interactively, don't do anything
+      case $- in
+          *i*) ;;
+            *) return;;
+      esac
+    STDOUT
+
+    error = assert_raises(Tomo::Runtime::TaskAbortedError) { tester.run_task("env:setup") }
+    assert_match("only one application can be deployed", error.message)
+    assert_match("/var/www/oldapp/envrc", error.message)
   end
 end


### PR DESCRIPTION
There is a fundamental assumption in the tomo "env" tasks that only one application is being deployed to a given user@host. Some users have reported being confused and surprised when they deploy more than one app to the same user@host and things begin behaving strangely.

This limitation is documented in tomo's FAQ, but it would be even better if tomo would alert users earlier in the setup process before the second app is deployed and things start going sideways.

This commit modifies the `env:setup` task so that it is able to detect when a second app is being deployed to the same user@host. When this situation is detected it will halt the setup process with a detailed error message like this:

```
tomo run v1.2.0
→ Connecting to deployer@app.example.com
• env:setup
cat .bashrc

  ERROR: The env:setup task failed on deployer@app.example.com.

  Based on the contents of .bashrc, it looks like another application
  is already being deployed via tomo to this host, using the following envrc
  path:

    /home/deployer/apps/example/envrc

  Tomo is designed such that only one application can be deployed to a given
  user@host. To deploy multiple applications to the same host, use a separate
  deployer user per app. Refer to the tomo FAQ for details:

    https://tomo-deploy.com/#faq

  You may be receiving this message in error if you recently renamed or
  reconfigured your application. In this case, remove the references to the
  old envrc path in the host's .bashrc and re-run env:setup.
```

Fixes #137, #138.