### PR TITLE
Use a more compact minitest reporter locally

### DIFF
--- a/test/support/reporters.rb
+++ b/test/support/reporters.rb
@@ -1,2 +1,7 @@
 require "minitest/reporters"
-Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new, ENV, Minitest.backtrace_filter)
+
+if ENV["CI"]
+  Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new)
+else
+  Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new)
+end


### PR DESCRIPTION
Tomo has quite a few tests now and the spec reporter we were using before produced many screen-fulls of output. Sometimes that made it hard to pinpoint failures. When running locally, use a more compact format to fix this.