### PR TITLE
Remove "Are you sure?" output when running tests

### DIFF
--- a/lib/tomo/console.rb
+++ b/lib/tomo/console.rb
@@ -12,9 +12,10 @@ module Tomo
       def_delegators :@instance, :interactive?, :prompt, :menu
     end
 
-    def initialize(env=ENV, input=$stdin)
+    def initialize(env=ENV, input=$stdin, output=$stdout)
       @env = env
       @input = input
+      @output = output
     end
 
     def interactive?
@@ -24,7 +25,7 @@ module Tomo
     def prompt(question)
       assert_interactive
 
-      print question
+      output.print question
       line = input.gets
       raise_non_interactive if line.nil?
 
@@ -39,7 +40,7 @@ module Tomo
 
     private
 
-    attr_reader :env, :input
+    attr_reader :env, :input, :output
 
     CI_VARS = %w[
       JENKINS_HOME

--- a/test/tomo/console_test.rb
+++ b/test/tomo/console_test.rb
@@ -14,8 +14,10 @@ class Tomo::ConsoleTest < Minitest::Test
   end
 
   def test_prompt_answer_does_not_contain_newline
-    console = Tomo::Console.new({}, tty("yes\n"))
+    stdout = StringIO.new
+    console = Tomo::Console.new({}, tty("yes\n"), stdout)
     answer = console.prompt("Are you sure? ")
+    assert_equal("Are you sure? ", stdout.string)
     assert_equal("yes", answer)
   end
 


### PR DESCRIPTION
Inject a dummy for stdout into `Tomo::Console` during tests so that it doesn't print directly to the real stdout. This cleans up test output so it is easier to keep track of pass/fail status.