### PR TITLE
Use CircleCI instead of Travis for testing older Ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,13 @@
 version: 2.1
 executors:
   ruby:
+    parameters:
+      version:
+        description: "Ruby version number"
+        default: "2.7.1"
+        type: string
     docker:
-      - image: circleci/ruby:2.7.1
+      - image: circleci/ruby:<< parameters.version >>
   python:
     docker:
       - image: circleci/python:3
@@ -10,10 +15,15 @@ executors:
 commands:
   bundle_install:
     description: Install Ruby dependencies with Bundler
+    parameters:
+      version:
+        description: "Ruby version number"
+        default: "2.7.1"
+        type: string
     steps:
       - restore_cache:
           keys:
-            - bundle-v1-{{ arch }}
+            - bundle-v1-{{ arch }}-<< parameters.version >>
       - run:
           name: Install Ruby Dependencies
           command: |
@@ -23,7 +33,7 @@ commands:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: bundle-v1-{{ arch }}-{{ checksum "Gemfile.lock" }}
+          key: bundle-v1-{{ arch }}-<< parameters.version >>-{{ checksum "Gemfile.lock" }}
   pip_install:
     description: Install Python dependencies
     steps:
@@ -73,10 +83,18 @@ jobs:
       - run: bundle exec rubocop
 
   test_unit:
-    executor: ruby
+    parameters:
+      version:
+        description: "Ruby version number"
+        default: "2.7.1"
+        type: string
+    executor:
+      name: ruby
+      version: << parameters.version >>
     steps:
       - checkout
-      - bundle_install
+      - bundle_install:
+          version: << parameters.version >>
       - run: bundle exec rake test:unit TESTOPTS="--ci-dir=./reports"
       - store_test_results:
           path: ./reports
@@ -107,13 +125,19 @@ workflows:
               only:
                 - main
       - rubocop
-      - test_unit
+      - test_unit:
+          matrix:
+            parameters:
+              version: ["2.5.8", "2.6.6", "2.7.1"]
       - test_e2e
   cron-workflow:
     jobs:
       - mkdocs_build
       - rubocop
-      - test_unit
+      - test_unit:
+          matrix:
+            parameters:
+              version: ["2.5.8", "2.6.6", "2.7.1"]
       - test_e2e
     triggers:
       - schedule:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ branches:
   only:
   - main
 rvm:
-- 2.5.8
-- 2.6.6
-- 2.7.1
 - ruby-head
 before_install: gem install bundler -v 2.1.4
 script: bundle exec rake test:unit

--- a/Rakefile
+++ b/Rakefile
@@ -40,16 +40,14 @@ namespace :bump do
     lowest = RubyVersions.lowest_supported
     lowest_minor = RubyVersions.lowest_supported_minor
     latest = RubyVersions.latest
+    latest_patches = RubyVersions.latest_supported_patches
 
     replace_in_file "tomo.gemspec", /ruby_version = .*">= (.*)"/ => lowest
     replace_in_file ".rubocop.yml", /TargetRubyVersion: (.*)/ => lowest_minor
-    replace_in_file ".circleci/config.yml", %r{circleci/ruby:([\d.]+)} => latest
+    replace_in_file ".circleci/config.yml", /default: "([\d.]+)"/ => latest
+    replace_in_file ".circleci/config.yml", /version: (\[.+\])/ => latest_patches.inspect
     replace_in_file ".circleci/Dockerfile", %r{circleci/ruby:([\d.]+)} => latest
     replace_in_file "docs/comparisons.md", /ruby version\s*\|\s*([\d.]+)/i => lowest_minor
-
-    travis = YAML.safe_load(open(".travis.yml"))
-    travis["rvm"] = RubyVersions.latest_supported_patches + ["ruby-head"]
-    IO.write(".travis.yml", YAML.dump(travis))
   end
 
   task :year do


### PR DESCRIPTION
CircleCI is faster and more reliable than Travis in my experience. We can't use CircleCI for every test, because it lacks an easy way to use ruby-head. However for every other version of Ruby, we can use matrix parameters in CircleCI to run our unit tests, rather than Travis.