### PR TITLE
Explicitly tag image to fix test failures with new Docker version

### DIFF
--- a/lib/tomo/testing/docker_image.rb
+++ b/lib/tomo/testing/docker_image.rb
@@ -80,9 +80,9 @@ module Tomo
       end
 
       def build_image
-        Local.capture(
-          "docker build #{build_dir}"
-        )[/Successfully built (\S+)$/i, 1]
+        tag = "tomo_testing:latest"
+        Local.capture("docker build --tag #{tag} #{build_dir}")
+        tag
       end
 
       def start_container


### PR DESCRIPTION
The latest version of Docker (installed via the docker-edge homebrew cask) changes how the image ID is returned from the `docker build` command. This causes tomo's docker tests to break.

Fix by explicitly tagging the image that is being built rather than trying to parse the image ID from the `docker build` output.