### PR TITLE
Autodetect rbenv_ruby_version via .ruby-version file

### DIFF
--- a/docs/plugins/rbenv.md
+++ b/docs/plugins/rbenv.md
@@ -4,9 +4,9 @@ The rbenv plugin provides a way to install and run a desired version of ruby. Th
 
 ## Settings
 
-| Name                 | Purpose                                      | Default     |
-| -------------------- | -------------------------------------------- | ----------- |
-| `bashrc_path`        | Location of the deploy user’s `.bashrc` file | `".bashrc"` |
+| Name                 | Purpose                                                                                        | Default     |
+| -------------------- | ---------------------------------------------------------------------------------------------- | ----------- |
+| `bashrc_path`        | Location of the deploy user’s `.bashrc` file                                                   | `".bashrc"` |
 | `rbenv_ruby_version` | Version of ruby to install. if nil (the default), determine the version based on .ruby-version | `nil`       |
 
 ## Tasks

--- a/docs/plugins/rbenv.md
+++ b/docs/plugins/rbenv.md
@@ -7,7 +7,7 @@ The rbenv plugin provides a way to install and run a desired version of ruby. Th
 | Name                 | Purpose                                      | Default     |
 | -------------------- | -------------------------------------------- | ----------- |
 | `bashrc_path`        | Location of the deploy user’s `.bashrc` file | `".bashrc"` |
-| `rbenv_ruby_version` | Version of ruby to install                   | `nil`       |
+| `rbenv_ruby_version` | Version of ruby to install. if nil (the default), determine the version based on .ruby-version | `nil`       |
 
 ## Tasks
 
@@ -17,6 +17,6 @@ Installs rbenv, uses rbenv to install ruby, and makes the desired version of rub
 
 Behind the scenes, rbenv installs ruby via ruby-build, which compiles ruby from source. This means installation can take several minutes. If the desired version of ruby is already installed, the compilation step will be skipped.
 
-You must supply a value for the `rbenv_ruby_version` setting for this task to work.
+You must supply a value for the `rbenv_ruby_version` setting or `.ruby-version` file for this task to work.
 
 `rbenv:install` is intended for use as a [setup](../commands/setup.md) task.

--- a/lib/tomo/plugin/rbenv/tasks.rb
+++ b/lib/tomo/plugin/rbenv/tasks.rb
@@ -31,8 +31,7 @@ module Tomo::Plugin::Rbenv
     end
 
     def compile_ruby
-      require_setting :rbenv_ruby_version
-      ruby_version = settings[:rbenv_ruby_version]
+      ruby_version = version_setting || extract_ruby_ver_from_version_file
 
       unless ruby_installed?(ruby_version)
         logger.info(
@@ -50,6 +49,20 @@ module Tomo::Plugin::Rbenv
         return true
       end
       false
+    end
+
+    def version_setting
+      settings[:rbenv_ruby_version]
+    end
+
+    def extract_ruby_ver_from_version_file
+      path = paths.release.join(".ruby-version")
+      return File.read(path).strip if File.exist?(path)
+
+      die <<~REASON
+        Could not guess ruby version from .ruby-version file.
+        Use the :rbenv_ruby_version setting to specify the version of ruby to install.
+      REASON
     end
   end
 end

--- a/lib/tomo/plugin/rbenv/tasks.rb
+++ b/lib/tomo/plugin/rbenv/tasks.rb
@@ -57,7 +57,8 @@ module Tomo::Plugin::Rbenv
 
     def extract_ruby_ver_from_version_file
       path = paths.release.join(".ruby-version")
-      return File.read(path).strip if File.exist?(path)
+      version = remote.capture("cat", path, raise_on_error: false).strip
+      return version unless version.empty?
 
       die <<~REASON
         Could not guess ruby version from .ruby-version file.

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -14,7 +14,6 @@ host "user@hostname.or.ip.address"
 
 set application: <%= app.inspect %>
 set deploy_to: "/var/www/%{application}"
-set rbenv_ruby_version: <%= RUBY_VERSION.inspect %>
 set nodenv_node_version: <%= node_version&.inspect || "nil # FIXME" %>
 set nodenv_yarn_version: <%= yarn_version.inspect %>
 set git_url: <%= git_origin_url&.inspect || "nil # FIXME" %>


### PR DESCRIPTION
Make `rbenv_ruby_version` setting optional in favor of reading the value from `.ruby-version` file.

references #186