### PR TITLE
Generate config.rb with explicit Ruby version, if needed

### DIFF
--- a/lib/tomo/commands/init.rb
+++ b/lib/tomo/commands/init.rb
@@ -99,6 +99,10 @@ module Tomo
         Gem::Requirement.new(">= 2.2").satisfied_by?(erb_version)
       end
 
+      def ruby_version_file?
+        File.exist?(".ruby-version")
+      end
+
       def config_rb_template(app)
         path = File.expand_path("../templates/config.rb.erb", __dir__)
         template = IO.read(path)

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -14,6 +14,9 @@ host "user@hostname.or.ip.address"
 
 set application: <%= app.inspect %>
 set deploy_to: "/var/www/%{application}"
+<% unless ruby_version_file? -%>
+set rbenv_ruby_version: <%= RUBY_VERSION.inspect %>
+<% end -%>
 set nodenv_node_version: <%= node_version&.inspect || "nil # FIXME" %>
 set nodenv_yarn_version: <%= yarn_version.inspect %>
 set git_url: <%= git_origin_url&.inspect || "nil # FIXME" %>


### PR DESCRIPTION
### Problem

If a project lacks a `.ruby-version` file, then `tomo setup` will fail if `rbenv_ruby_version` is not explicitly specified. Currently tomo does not include a `rbenv_ruby_version` setting in the default `.tomo/config.rb` file.

### Solution

We can make the user's life a lot easier in this scenario by providing a default value when they initialize tomo.

This commit enhances `tomo init` so that if a `.ruby-version` is not present, tomo will include a `set rbenv_ruby_version: ...` setting in the generated `.tomo/config.rb` based on the currently executing version of Ruby.