### PR TITLE
Fix broken "edit on GitHub" links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ markdown_extensions:
   - markdown_include.include:
       base_path: docs/include
 repo_url: https://github.com/mattbrictson/tomo/
+edit_uri: edit/main/docs/
 nav:
   - Home: index.md
   - Comparisons: comparisons.md


### PR DESCRIPTION
The default for mkdocs is `edit/master/docs/` which yields a 404 for this repo. Update the config to use `edit/main/docs/`, which works.