### PR TITLE
Gracefully handle non-standard .ruby-version files

### DIFF
--- a/lib/tomo/commands/init.rb
+++ b/lib/tomo/commands/init.rb
@@ -100,8 +100,13 @@ module Tomo
         Gem::Requirement.new(">= 2.2").satisfied_by?(erb_version)
       end
 
-      def ruby_version_file?
-        File.exist?(".ruby-version")
+      # Does a .ruby-version file exist match the executing RUBY_VERSION?
+      def using_ruby_version_file?
+        return false unless File.exist?(".ruby-version")
+
+        IO.read(".ruby-version").rstrip == RUBY_VERSION
+      rescue IOError
+        false
       end
 
       def config_rb_template(app)

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -14,7 +14,7 @@ host "user@hostname.or.ip.address"
 
 set application: <%= app.inspect %>
 set deploy_to: "/var/www/%{application}"
-<% unless ruby_version_file? -%>
+<% unless using_ruby_version_file? -%>
 set rbenv_ruby_version: <%= RUBY_VERSION.inspect %>
 <% end -%>
 set nodenv_node_version: <%= node_version&.inspect || "nil # FIXME" %>


### PR DESCRIPTION
`tomo init` looks for the presence of a `.ruby-version` file. If that file exists, then the `.tomo/config.rb` file will omit an explicit setting for `:rbenv_ruby_version`. That's because tomo assumes it will be able to auto-detect the version at setup time.

However, if `.ruby-version` contains bad data, or a value that rbenv doesn't understand, that means that the user will be in for an unpleasant surprise: `tomo setup` will fail because it tries to guess the `:rbenv_ruby_version` from the `.ruby-version` file, and fails.

This commit fixes this problem with the following solution:

`tomo init` will omit the `:rbenv_ruby_version` setting only if the `.ruby-version` file contains an actual Ruby version number and that version number matches `RUBY_VERSION`. That way the auto-detection should be guaranteed to work.

Fixes #211