### PR TITLE
Suggest `bundle exec` to fix missing plugin errors

### DIFF
--- a/lib/tomo/configuration/unknown_plugin_error.rb
+++ b/lib/tomo/configuration/unknown_plugin_error.rb
@@ -17,11 +17,22 @@ module Tomo
       private
 
       def gem_suggestion
-        if Tomo.bundled?
-          "\nYou may need to add #{yellow(gem_name)} to your Gemfile."
-        else
-          "\nYou may need to install the #{yellow(gem_name)} gem."
+        return "\nYou may need to add #{yellow(gem_name)} to your Gemfile." if Tomo.bundled?
+
+        messages = ["\nYou may need to install the #{yellow(gem_name)} gem."]
+        if present_in_gemfile?
+          messages << "\nTry prefixing the tomo command with #{blue('bundle exec')} to fix this error."
         end
+
+        messages.join
+      end
+
+      def present_in_gemfile?
+        return false unless File.file?("Gemfile")
+
+        IO.read("Gemfile").match?(/^\s*gem ['"]#{Regexp.quote(gem_name)}['"]/)
+      rescue IOError
+        false
       end
     end
   end


### PR DESCRIPTION
If a user installs tomo and tomo plugins via a Gemfile, but then runs tomo without using `bundle exec`, this can lead to errors like this:

```
ERROR: sidekiq is not a recognized plugin.
You may need to install the tomo-plugin-sidekiq gem.
```

This is because the plugins in the Gemfile are not available when tomo is run without `bundle exec`.

Until now, tomo's error message doesn't really make this clear.

This commit improves the error message so that it now says:

```
ERROR: sidekiq is not a recognized plugin.
You may need to install the tomo-plugin-sidekiq gem.
Try prefixing the tomo command with bundle exec to fix this error.
```

tomo will only suggest `bundle exec` if it is fairly certain that it will fix the error: there is a Gemfile present and it contains a `gem` entry for the missing plugin.