### PR TITLE
Fix failing `rbenv:install` task `rbenv: command not found`

### DIFF
--- a/lib/tomo/plugin/rbenv/tasks.rb
+++ b/lib/tomo/plugin/rbenv/tasks.rb
@@ -11,7 +11,7 @@ module Tomo::Plugin::Rbenv
     private
 
     def run_installer
-      install_url = "https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer"
+      install_url = "https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer"
       remote.env PATH: raw("$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH") do
         remote.run("curl -fsSL #{install_url.shellescape} | bash")
       end


### PR DESCRIPTION
The rbenv-installer project has changed the location of its installation script to:

https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer

Update tomo's `rbenv:install` task to match.

This fixes a bug where tomo would fail to install ruby with an error like this:

    bash: rbenv: command not found