### PR TITLE
Switch to more stable GitHub URLs for docs, nodenv

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -125,7 +125,7 @@ module RubyVersions
 
     def versions
       @_versions ||= begin
-        yaml = URI.open("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/downloads.yml")
+        yaml = URI.open("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/HEAD/_data/downloads.yml")
         YAML.safe_load(yaml, symbolize_names: true)
       end
     end

--- a/docs/plugins/puma.md
+++ b/docs/plugins/puma.md
@@ -1,6 +1,6 @@
 # puma
 
-The puma plugin provides a [systemd](https://en.wikipedia.org/wiki/Systemd)-based solution for starting, stopping, and restarting puma using [socket activation][socket-activation] for zero-downtime restarts. It is based on the best practices in the [official puma documentation](https://github.com/puma/puma/blob/master/docs/systemd.md).
+The puma plugin provides a [systemd](https://en.wikipedia.org/wiki/Systemd)-based solution for starting, stopping, and restarting puma using [socket activation][socket-activation] for zero-downtime restarts. It is based on the best practices in the [official puma documentation](https://github.com/puma/puma/blob/HEAD/docs/systemd.md).
 
 Tomo's implementation installs puma as a _user-level_ service using `systemctl --user`. This allows puma to be installed, started, stopped, and restarted without a root user or `sudo`. However, when provisioning the host you must make sure to run the following command as root to allow the puma process to continue running even after the tomo deploy user disconnects:
 
@@ -122,4 +122,4 @@ journalctl -q --user-unit=puma.service -f
 
 A convenience method for tailing the puma logs. Equivalent to `tomo run -- puma:log -f`
 
-[socket-activation]: https://github.com/puma/puma/blob/master/docs/systemd.md#socket-activation
+[socket-activation]: https://github.com/puma/puma/blob/HEAD/docs/systemd.md#socket-activation

--- a/lib/tomo/plugin/nodenv/tasks.rb
+++ b/lib/tomo/plugin/nodenv/tasks.rb
@@ -12,7 +12,7 @@ module Tomo::Plugin::Nodenv
     private
 
     def run_installer
-      install_url = "https://github.com/nodenv/nodenv-installer/raw/master/bin/nodenv-installer"
+      install_url = "https://github.com/nodenv/nodenv-installer/raw/HEAD/bin/nodenv-installer"
       remote.env PATH: raw("$HOME/.nodenv/bin:$HOME/.nodenv/shims:$PATH") do
         remote.run("curl -fsSL #{install_url.shellescape} | bash")
       end


### PR DESCRIPTION
Many projects are in the process of renaming the default branch of their repositories. Rather than point to the default branch by name (e.g. `master`), use `HEAD` so that URLs will continue to work even if the branch is renamed in the future.