### PR TITLE
Add automatic support for yarn v2+

### DIFF
--- a/docs/plugins/nodenv.md
+++ b/docs/plugins/nodenv.md
@@ -1,14 +1,15 @@
 # nodenv
 
-The nodenv plugin installs node and optionally yarn via nodenv. This allows you to deploy an app with confidence that particular versions of these tools will be available on the host. This plugin is strongly recommended for Rails apps, which by default use webpacker and thus require node and yarn.
+The nodenv plugin installs node and yarn. This allows you to deploy an app with confidence that yarn and a particular version of node will be available on the host. This plugin is strongly recommended for Rails apps, which by default use webpacker and thus require node and yarn.
 
 ## Settings
 
-| Name                  | Purpose                                      | Default     |
-| --------------------- | -------------------------------------------- | ----------- |
-| `bashrc_path`         | Location of the deploy user’s `.bashrc` file | `".bashrc"` |
-| `nodenv_node_version` | Version of node to install                   | `nil`       |
-| `nodenv_yarn_version` | Version of yarn to install                   | `nil`       |
+| Name                  | Purpose                                                                                                                        | Default     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| `bashrc_path`         | Location of the deploy user’s `.bashrc` file                                                                                   | `".bashrc"` |
+| `nodenv_install_yarn` | Whether to install yarn globally via `npm i -g yarn`                                                                           | `true`      |
+| `nodenv_node_version` | Version of node to install                                                                                                     | `nil`       |
+| `nodenv_yarn_version` | A value of `nil` (the default) means install the latest; specify this only if you need a specific 1.y.z global version of yarn | `nil`       |
 
 ## Tasks
 
@@ -16,6 +17,8 @@ The nodenv plugin installs node and optionally yarn via nodenv. This allows you 
 
 Installs nodenv, uses nodenv to install node, and makes the desired version of node the global default version for the deploy user. During installation, the user’s bashrc file is modified so that nodenv is automatically loaded for interactive and non-interactive shells.
 
-You must supply a value for the `nodenv_node_version` setting for this task to work. If the `nodenv_yarn_version` setting is specified, yarn is also installed globally via npm. This setting is optional.
+You must supply a value for the `nodenv_node_version` setting for this task to work.
+
+By default, yarn is also installed globally via npm. This can be disabled by setting `nodenv_install_yarn` to `false`.
 
 `nodenv:install` is intended for use as a [setup](../commands/setup.md) task.

--- a/lib/tomo/plugin/nodenv.rb
+++ b/lib/tomo/plugin/nodenv.rb
@@ -5,6 +5,7 @@ module Tomo::Plugin
     extend Tomo::PluginDSL
 
     defaults bashrc_path: ".bashrc",
+             nodenv_install_yarn: true,
              nodenv_node_version: nil,
              nodenv_yarn_version: nil
 

--- a/lib/tomo/plugin/nodenv/tasks.rb
+++ b/lib/tomo/plugin/nodenv/tasks.rb
@@ -39,10 +39,14 @@ module Tomo::Plugin::Nodenv
     end
 
     def install_yarn
-      version = settings[:nodenv_yarn_version]
-      return remote.run "npm i -g yarn@#{version.shellescape}" if version
+      unless settings[:nodenv_install_yarn]
+        logger.info ":nodenv_install_yarn is false; skipping yarn installation."
+        return
+      end
 
-      logger.info "No :nodenv_yarn_version specified; skipping yarn installation."
+      version = settings[:nodenv_yarn_version]
+      yarn_spec = version ? "yarn@#{version.shellescape}" : "yarn"
+      remote.run "npm i -g #{yarn_spec}"
     end
 
     def node_installed?(version)

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -35,6 +35,7 @@ set env_vars: {
   SECRET_KEY_BASE: :prompt
 }
 set linked_dirs: %w[
+  .yarn/cache
   log
   node_modules
   public/assets

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -18,7 +18,7 @@ set deploy_to: "/var/www/%{application}"
 set rbenv_ruby_version: <%= RUBY_VERSION.inspect %>
 <% end -%>
 set nodenv_node_version: <%= node_version&.inspect || "nil # FIXME" %>
-set nodenv_yarn_version: <%= yarn_version.inspect %>
+set nodenv_install_yarn: <%= yarn_version ? "true" : "false" %>
 set git_url: <%= git_origin_url&.inspect || "nil # FIXME" %>
 set git_branch: <%= git_branch&.inspect || "nil # FIXME" %>
 set git_exclusions: %w[

--- a/test/tomo/plugin/nodenv/tasks_test.rb
+++ b/test/tomo/plugin/nodenv/tasks_test.rb
@@ -57,6 +57,12 @@ class Tomo::Plugin::Nodenv::TasksTest < Minitest::Test
     refute_empty tester.executed_scripts.grep("nodenv global 10.15.3")
   end
 
+  def test_install_uses_npm_to_install_yarn_by_default
+    tester = configure(nodenv_node_version: "10.15.3")
+    tester.run_task("nodenv:install")
+    refute_empty tester.executed_scripts.grep("npm i -g yarn")
+  end
+
   def test_install_uses_npm_to_install_specified_version_of_yarn
     tester = configure(
       nodenv_node_version: "10.15.3",
@@ -66,8 +72,11 @@ class Tomo::Plugin::Nodenv::TasksTest < Minitest::Test
     refute_empty tester.executed_scripts.grep("npm i -g yarn@1.17.3")
   end
 
-  def test_install_skips_yarn_if_no_yarn_version_specified
-    tester = configure(nodenv_node_version: "10.15.3")
+  def test_install_skips_yarn_if_explicitly_disabled
+    tester = configure(
+      nodenv_node_version: "10.15.3",
+      nodenv_install_yarn: false
+    )
     tester.run_task("nodenv:install")
     assert_empty tester.executed_scripts.grep(/yarn/)
   end


### PR DESCRIPTION
## Problem

Apps that use yarn v2 or v3 follow a pattern like this:

- Yarn v1 (legacy) is installed globally
- The desired version of yarn (2.x or 3.x) is packaged in the app itself, in `.yarn/releases`

Furthermore:

- `node_modules` is no longer the basis for caching downloaded node packages
- The default cache location is `.yarn/cache` within the project directory

## Solution

This PR makes some minor tweaks to tomo to support yarn v2+ without breaking existing yarn v1 apps.

**Link yarn v2 cache directory for faster deploys.** In yarn v2 and later, yarn places its cache in `.yarn/cache` of the project directory by default. Linking `node_modules` is not sufficient for eliminating re-downloading of packages across deploys. To avoid re-downloads, we need to link the cache directory.

**Allow yarn to be installed globally without specifying a version.** Starting with yarn v2, the global version of yarn is 1.x, and it is up to the project to provide its desired version of yarn. For tomo, that introduces some ambiguity. The nodenv plugin has a setting for `:nodenv_yarn_version`. Which version is this talking about? The global version of yarn or the project one?

To address this confusion, this PR changes tomo's behavior to no longer require `:nodenv_yarn_version`. Instead, tomo will always install yarn globally by default, without a version specifier. This will result in yarn 1.x getting installed globally, which is what is appropriate for typical yarn usage.

If a project needs a specific version of yarn, the proper way to do that is within the source code of the project itself (`.yarnrc.yml`), not by installing a different global version of yarn.

The `:nodenv_node_version` setting remains in tomo, but it is no longer recommended.
