### PR TITLE
Use private cache location for bootsnap to avoid endless accumulation of data

### DIFF
--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -31,6 +31,7 @@ set env_vars: {
   RAILS_ENV: "production",
   RAILS_LOG_TO_STDOUT: "1",
   RAILS_SERVE_STATIC_FILES: "1",
+  BOOTSNAP_CACHE_DIR: "tmp/bootsnap-cache",
   DATABASE_URL: :prompt,
   SECRET_KEY_BASE: :prompt
 }


### PR DESCRIPTION
# Problem

The `bootsnap` gem is commonly used in Rails apps to improve boot performance. Part of its approach is to create caches for locating gems. These caches are by default stored in `tmp/cache`.

Out of the box, tomo links `tmp/cache` to its shared area. This means that the cache is shared and reused for every tomo release.

This sounds desirable, but in practice it is problematic. There is no way to clean the bootsnap cache, so every time a new gem or gem version is added to an app, the cache grows. Over the lifetime of a project, this accumulation can become significant.

More seriously, the bootsnap cache is sensitive to the absolute path of the app that is being run. In tomo, each release is deployed to a unique directory name based on the timestamp of the release. That means that each tomo release causes the shared bootsnap cache to grow in size. If a project is deployed daily, this can quickly grow to be gigabytes.

# Solution

The solution, for new tomo projects, is to specify a value for the `BOOTSNAP_CACHE_DIR` environment variable. Instead of the default, `tmp/cache`, which is symlinked to tomo's shared location, we use a different value that will not be symlinked.

Thus, each tomo release will get its own, private bootsnap cache. Since tomo cleans up old releases on a regular basis, these caches will naturally be cleaned up as well.