### PR TITLE
Ensure git is configured with a valid `user.name` and `user.email`

### DIFF
--- a/docs/plugins/git.md
+++ b/docs/plugins/git.md
@@ -12,8 +12,23 @@ The git plugin uses git running on the remote host to fetch the code of the app 
 | `git_env`        | Environment variables that will be set when issuing git commands (hash)                                                                                                                                               | `{ GIT_SSH_COMMAND: "ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no" }` |
 | `git_ref`        | The commit SHA or tag to deploy (overrides `:git_branch`)                                                                                                                                                             | `nil`                                                                                 |
 | `git_url`        | URL of the git repository; always use the SSH form like `git@github.com:username/repo.git` (not HTTPS)                                                                                                                | `nil`                                                                                 |
+| `git_user_name`        | The value to use for git's `user.name` config                                                                                                                | `nil`                                                                                 |
+| `git_user_email`        | The value to use for git's `user.email` config                                                                                                            | `nil`                                                                                 |
 
 ## Tasks
+
+### git:config
+
+Globally (for the deployer user) configures git with values for `user.name` and `user.email` so that certain git commands are able to function. By default, tomo will use the deployer username and append `@example.com` to generate these values, like this:
+
+```
+git config --global user.name deployer
+git config --global user.email deployer@example.com
+```
+
+If you wish to customize the name and email values, use the `git_user_name` and `git_user_email` settings.
+
+`git:config` is intended for use as a [setup](../commands/setup.md) task.
 
 ### git:clone
 

--- a/lib/tomo/plugin/git.rb
+++ b/lib/tomo/plugin/git.rb
@@ -12,6 +12,8 @@ module Tomo::Plugin
              git_exclusions: [],
              git_env:        { GIT_SSH_COMMAND: "ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no" },
              git_ref:        nil,
-             git_url:        nil
+             git_url:        nil,
+             git_user_name:  nil,
+             git_user_email: nil
   end
 end

--- a/lib/tomo/plugin/git/tasks.rb
+++ b/lib/tomo/plugin/git/tasks.rb
@@ -3,6 +3,14 @@ require "time"
 
 module Tomo::Plugin::Git
   class Tasks < Tomo::TaskLibrary
+    def config
+      user_name = settings[:git_user_name] || remote.host.user
+      user_email = settings[:git_user_email] || "#{remote.host.user}@example.com"
+
+      remote.git("config", "--global", "user.name", user_name)
+      remote.git("config", "--global", "user.email", user_email)
+    end
+
     def clone
       require_setting :git_url
 

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -49,6 +49,7 @@ set linked_dirs: %w[
 setup do
   run "env:setup"
   run "core:setup_directories"
+  run "git:config"
   run "git:clone"
   run "git:create_release"
   run "core:symlink_shared"

--- a/test/tomo/plugin/git/tasks_test.rb
+++ b/test/tomo/plugin/git/tasks_test.rb
@@ -2,6 +2,33 @@ require "test_helper"
 require "tomo/plugin/git"
 
 class Tomo::Plugin::Git::TasksTest < Minitest::Test
+  def test_config_sets_name_and_email_with_user_by_default
+    tester = configure
+    tester.run_task("git:config")
+    assert_equal(
+      [
+        "git config --global user.name testing",
+        "git config --global user.email testing@example.com"
+      ],
+      tester.executed_scripts
+    )
+  end
+
+  def test_config_sets_name_and_email_based_on_settings
+    tester = configure(
+      git_user_name: "ahoy user",
+      git_user_email: "hello@test.biz"
+    )
+    tester.run_task("git:config")
+    assert_equal(
+      [
+        "git config --global user.name ahoy\\ user",
+        "git config --global user.email hello@test.biz"
+      ],
+      tester.executed_scripts
+    )
+  end
+
   def test_create_release_uses_branch_if_specified
     tester = configure(git_branch: "develop")
     tester.run_task("git:create_release")


### PR DESCRIPTION
Certain operations, like the `git pull` issued by the `rbenv` installer, require that the git client on the remote host is configured with a valid `user.name` and `user.email`.

Git will try to auto-detect values for these settings, but depending on the host, this may not always be possible.

When this auto-detection fails, tomo will fail with errors like this:

```
*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address
```

Fix by introducing a new tomo task that runs during setup: `git:config`. This will explicitly set the `user.name` and `user.email` values, so that auto-detection is no longer necessary.