### PR TITLE
Use node version from .node-version file, if present

### DIFF
--- a/docs/plugins/nodenv.md
+++ b/docs/plugins/nodenv.md
@@ -8,7 +8,7 @@ The nodenv plugin installs node and yarn. This allows you to deploy an app with 
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------- |
 | `bashrc_path`         | Location of the deploy user’s `.bashrc` file                                                                                   | `".bashrc"` |
 | `nodenv_install_yarn` | Whether to install yarn globally via `npm i -g yarn`                                                                           | `true`      |
-| `nodenv_node_version` | Version of node to install                                                                                                     | `nil`       |
+| `nodenv_node_version` | Version of node to install; if nil (the default), determine the version based on .node-version                                 | `nil`       |
 | `nodenv_yarn_version` | A value of `nil` (the default) means install the latest; specify this only if you need a specific 1.y.z global version of yarn | `nil`       |
 
 ## Tasks
@@ -17,7 +17,7 @@ The nodenv plugin installs node and yarn. This allows you to deploy an app with 
 
 Installs nodenv, uses nodenv to install node, and makes the desired version of node the global default version for the deploy user. During installation, the user’s bashrc file is modified so that nodenv is automatically loaded for interactive and non-interactive shells.
 
-You must supply a value for the `nodenv_node_version` setting for this task to work.
+You must supply a value for the `nodenv_node_version` setting or have a `.node-version` file in your project for this task to work.
 
 By default, yarn is also installed globally via npm. This can be disabled by setting `nodenv_install_yarn` to `false`.
 

--- a/docs/plugins/rbenv.md
+++ b/docs/plugins/rbenv.md
@@ -7,7 +7,7 @@ The rbenv plugin provides a way to install and run a desired version of ruby. Th
 | Name                 | Purpose                                                                                        | Default     |
 | -------------------- | ---------------------------------------------------------------------------------------------- | ----------- |
 | `bashrc_path`        | Location of the deploy user’s `.bashrc` file                                                   | `".bashrc"` |
-| `rbenv_ruby_version` | Version of ruby to install. if nil (the default), determine the version based on .ruby-version | `nil`       |
+| `rbenv_ruby_version` | Version of ruby to install; if nil (the default), determine the version based on .ruby-version | `nil`       |
 
 ## Tasks
 
@@ -17,6 +17,6 @@ Installs rbenv, uses rbenv to install ruby, and makes the desired version of rub
 
 Behind the scenes, rbenv installs ruby via ruby-build, which compiles ruby from source. This means installation can take several minutes. If the desired version of ruby is already installed, the compilation step will be skipped.
 
-You must supply a value for the `rbenv_ruby_version` setting or `.ruby-version` file for this task to work.
+You must supply a value for the `rbenv_ruby_version` setting or have a `.ruby-version` file in your project for this task to work.
 
 `rbenv:install` is intended for use as a [setup](../commands/setup.md) task.

--- a/lib/tomo/commands/init.rb
+++ b/lib/tomo/commands/init.rb
@@ -104,6 +104,16 @@ module Tomo
         false
       end
 
+      # Does a .node-version file exist match `node --version`?
+      def using_node_version_file?
+        return false unless File.exist?(".node-version")
+
+        version = File.read(".node-version").rstrip
+        !version.empty? && version == node_version
+      rescue IOError
+        false
+      end
+
       def config_rb_template(app)
         path = File.expand_path("../templates/config.rb.erb", __dir__)
         template = File.read(path)

--- a/lib/tomo/plugin/nodenv/tasks.rb
+++ b/lib/tomo/plugin/nodenv/tasks.rb
@@ -31,8 +31,7 @@ module Tomo::Plugin::Nodenv
     end
 
     def install_node
-      require_setting :nodenv_node_version
-      node_version = settings[:nodenv_node_version]
+      node_version = settings[:nodenv_node_version] || extract_node_ver_from_version_file
 
       remote.run "nodenv install #{node_version.shellescape}" unless node_installed?(node_version)
       remote.run "nodenv global #{node_version.shellescape}"
@@ -56,6 +55,17 @@ module Tomo::Plugin::Nodenv
         return true
       end
       false
+    end
+
+    def extract_node_ver_from_version_file
+      path = paths.release.join(".node-version")
+      version = remote.capture("cat", path, raise_on_error: false).strip
+      return version unless version.empty?
+
+      die <<~REASON
+        Could not guess node version from .node-version file.
+        Use the :nodenv_node_version setting to specify the version of node to install.
+      REASON
     end
   end
 end

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -17,7 +17,9 @@ set deploy_to: "/var/www/%{application}"
 <% unless using_ruby_version_file? -%>
 set rbenv_ruby_version: <%= RUBY_VERSION.inspect %>
 <% end -%>
+<% unless using_node_version_file? -%>
 set nodenv_node_version: <%= node_version&.inspect || "nil # FIXME" %>
+<% end -%>
 set nodenv_install_yarn: <%= yarn_version ? "true" : "false" %>
 set git_url: <%= git_origin_url&.inspect || "nil # FIXME" %>
 set git_branch: <%= git_branch&.inspect || "nil # FIXME" %>

--- a/test/tomo/commands/init_test.rb
+++ b/test/tomo/commands/init_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class Tomo::Commands::InitTest < Minitest::Test
+  def setup
+    @tester = Tomo::Testing::CLITester.new
+  end
+
+  def test_includes_node_version_setting_in_generated_config
+    @tester.in_temp_dir do
+      with_backtick_stub("node --version", "v16.14.0\n") do
+        @tester.run "init"
+
+        assert_match('set nodenv_node_version: "16.14.0"', File.read(".tomo/config.rb"))
+      end
+    end
+  end
+
+  def test_doesnt_include_node_version_setting_if_nodenv_version_file_is_present
+    @tester.in_temp_dir do
+      with_backtick_stub("node --version", "v16.14.0\n") do
+        File.write ".node-version", "16.14.0\n"
+        @tester.run "init"
+
+        refute_match(/nodenv_node_version/, File.read(".tomo/config.rb"))
+      end
+    end
+  end
+
+  private
+
+  def with_backtick_stub(command, result)
+    Tomo::Commands::Init.define_method(:`) do |arg|
+      arg == command ? result : Kernel.send(:`, arg)
+    end
+    yield
+  ensure
+    Tomo::Commands::Init.remove_method(:`)
+  end
+end


### PR DESCRIPTION
If the project being deployed with tomo has a `.node-version` file, the `nodenv:install` task can now infer the node version from that file. This means that the `nodenv_node_version` setting is no longer required.