### PR TITLE
Pin markdown to work around mkdocs error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+markdown == 3.3.7
 markdown_include == 0.6.0
 mdx_truly_sane_lists == 1.2
 mkdocs == 1.3.0


### PR DESCRIPTION
Fixes:

> Config value: 'markdown_extensions'. Error: Failed loading extension "mdx_truly_sane_lists".