### PR TITLE
Fix "uninitialized constant" errors for StringIO and SimpleDelegator

### DIFF
--- a/lib/tomo/path.rb
+++ b/lib/tomo/path.rb
@@ -1,4 +1,4 @@
-require "forwardable"
+require "delegate"
 require "pathname"
 
 module Tomo

--- a/lib/tomo/ssh/child_process.rb
+++ b/lib/tomo/ssh/child_process.rb
@@ -1,5 +1,6 @@
 require "open3"
 require "shellwords"
+require "stringio"
 
 module Tomo
   module SSH

--- a/lib/tomo/testing/log_capturing.rb
+++ b/lib/tomo/testing/log_capturing.rb
@@ -1,3 +1,5 @@
+require "stringio"
+
 module Tomo
   module Testing
     module LogCapturing

--- a/test/tomo/console_test.rb
+++ b/test/tomo/console_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "stringio"
 
 class Tomo::ConsoleTest < Minitest::Test
   def test_interactive_is_true_for_tty


### PR DESCRIPTION
In instances when tomo is used without a Gemfile, or is used with a Gemfile that contains very few gems, running `tomo` might result in an "uninitialized constant" crash for `StringIO` or `SimpleDelegator`.

This happens because tomo is trying to use these constants without explicitly `require`-ing them. By luck, gems in a typical Gemfile will already require these, so by the time tomo runs, they have already been loaded. But this is not guaranteed.

Fix by using the proper `require` statements to insure that these constants are loaded.