### PR TITLE
Link `public/vite` by default for better `vite_rails` support

### DIFF
--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -43,6 +43,7 @@ set linked_dirs: %w[
   node_modules
   public/assets
   public/packs
+  public/vite
   tmp/cache
   tmp/pids
   tmp/sockets


### PR DESCRIPTION
[vite_rails](https://vite-ruby.netlify.app) hooks into `assets:precompile`, so it will already work fine with tomo's default deploy script. This commit adds `public/vite` to the default list of `linked_dirs` to make deploys faster, by allowing the output of vite's build to be reused across releases.