### PR TITLE
Add helper for running thor tasks with `remote.thor`

### DIFF
--- a/docs/plugins/rails.md
+++ b/docs/plugins/rails.md
@@ -107,3 +107,12 @@ Like `rake` but returns `true` if the command succeeds (exit status 0), otherwis
 ```ruby
 remote.rake?("db:migrate") # => true
 ```
+
+### remote.thor(\*args, \*\*options) → [Tomo::Result](../api/Result.md)
+
+Runs `bundle exec thor` in within `paths.release` by default.
+
+```ruby
+remote.thor("user:create")
+# $ cd /var/www/my-app/releases/20190604204415 && bundle exec thor user:create
+```

--- a/lib/tomo/plugin/rails/helpers.rb
+++ b/lib/tomo/plugin/rails/helpers.rb
@@ -16,5 +16,11 @@ module Tomo::Plugin::Rails
       result = rake(*args, **opts.merge(raise_on_error: false))
       result.success?
     end
+
+    def thor(*args, **opts)
+      prepend("exec", "thor") do
+        bundle(*args, **opts)
+      end
+    end
   end
 end

--- a/test/tomo/plugin/rails/helpers_test.rb
+++ b/test/tomo/plugin/rails/helpers_test.rb
@@ -7,4 +7,10 @@ class Tomo::Plugin::Rails::HelpersTest < Minitest::Test
     tester.call_helper(:rake, "db:migrate")
     assert_equal("cd /app/current && bundle exec rake db:migrate", tester.executed_script)
   end
+
+  def test_thor_runs_bundle_exec_thor_in_current_path
+    tester = Tomo::Testing::MockPluginTester.new("bundler", "rails", settings: { current_path: "/app/current" })
+    tester.call_helper(:thor, "user:create")
+    assert_equal("cd /app/current && bundle exec thor user:create", tester.executed_script)
+  end
 end


### PR DESCRIPTION
[Thor](https://github.com/rails/thor) is an alternative to rake for writing command-line scripts in Ruby. It is built into Rails and maintained under the Rails GitHub organization.

In a Rails project, you can place `.thor` files under `lib/tasks/` (for example). Similar to Rake, you can run `thor -T` to see a list of commands, and `thor COMMAND` to run a command defined in one your `.thor` files.

Thor offers a more intuitive programming model compared to rake, and has a more full-featured set of CLI options parsing capabilities. Most importantly, while rake tasks are notoriously tricky to unit test and require boilerplate to do so, thor commands can be unit tested like plain ruby methods.

This PR adds a `remote.thor` helper to tomo (similar to `remote.rake`) so that developers who are using thor to write CLI commands have easy access to them when writing custom tomo tasks.