### PR TITLE
Add `tomo -T` as an alias for `tomo tasks`

### DIFF
--- a/lib/tomo/cli.rb
+++ b/lib/tomo/cli.rb
@@ -32,6 +32,7 @@ module Tomo
       "run" => Tomo::Commands::Run,
       "setup" => Tomo::Commands::Setup,
       "tasks" => Tomo::Commands::Tasks,
+      "-T" => Tomo::Commands::Tasks,
       "version" => Tomo::Commands::Version,
       "completion-script" => Tomo::Commands::CompletionScript
     }.freeze

--- a/lib/tomo/commands/tasks.rb
+++ b/lib/tomo/commands/tasks.rb
@@ -24,7 +24,7 @@ module Tomo
 
         groups = tasks.group_by { |task| task[/^([^:]+):/, 1].to_s }
         groups.keys.sort.each do |group|
-          puts groups[group].sort.join("\n")
+          logger.info(groups[group].sort.join("\n"))
         end
       end
     end

--- a/test/tomo/cli_test.rb
+++ b/test/tomo/cli_test.rb
@@ -11,6 +11,13 @@ class Tomo::CLITest < Minitest::Test
     assert_match "Simulated bundler:install", @tester.stdout
   end
 
+  def test_dash_t_is_alias_for_tasks
+    @tester.run "init"
+    @tester.run "-T"
+    assert_match "core:clean_releases", @tester.stdout
+    assert_match "core:setup_directories", @tester.stdout
+  end
+
   def test_suggests_installing_missing_plugin
     @tester.run "init"
     @tester.run "foo:setup", raise_on_error: false


### PR DESCRIPTION
This makes tomo behave similarly to `rake -T`, `cap -T`, and `thor -T`.