### PR TITLE
Add libyaml-dev to Ubuntu recommended packages

### DIFF
--- a/docs/tutorials/deploying-rails-from-scratch.md
+++ b/docs/tutorials/deploying-rails-from-scratch.md
@@ -41,7 +41,8 @@ Rails requires certain operating system packages in order to build Ruby and inst
 # Run these commands as root on the VPS
 apt-get -y update
 apt-get -y install build-essential zlib1g-dev libssl-dev libreadline-dev \
-                   git-core curl locales libsqlite3-dev tzdata
+                   git-core curl locales libsqlite3-dev libyaml-dev \
+                   tzdata
 locale-gen en_US.UTF-8
 ```
 

--- a/lib/tomo/testing/ubuntu_setup.sh
+++ b/lib/tomo/testing/ubuntu_setup.sh
@@ -17,7 +17,8 @@ touch /var/lib/systemd/linger/deployer
 
 # Packages needed for ruby, etc.
 apt-get -y update
-apt-get -y install build-essential zlib1g-dev libssl-dev libreadline-dev git-core curl locales libsqlite3-dev
+apt-get -y install build-essential zlib1g-dev libssl-dev libreadline-dev \
+                   git-core curl locales libsqlite3-dev libyaml-dev
 
 apt-get -y install tzdata \
         -o DPkg::options::="--force-confdef" \


### PR DESCRIPTION
Compiling Ruby on Ubuntu in some cases requires libyaml-dev.