### PR TITLE
Fix erroneous "Ruby <VERSION> is already installed" message

### DIFF
--- a/lib/tomo/plugin/rbenv/tasks.rb
+++ b/lib/tomo/plugin/rbenv/tasks.rb
@@ -44,7 +44,7 @@ module Tomo::Plugin::Rbenv
 
     def ruby_installed?(version)
       versions = remote.capture("rbenv versions", raise_on_error: false)
-      if versions.include?(version)
+      if versions.match?(/^\*?\s*#{Regexp.quote(version)}\s/)
         logger.info("Ruby #{version} is already installed.")
         return true
       end


### PR DESCRIPTION
When a pre-release version of Ruby is already installed, e.g. 3.2.0-rc1, tomo would fail to install the final version (3.2.0) with the misleading message, "Ruby 3.2.0 is already installed".

Fix by using a more robust regular expression to detect existing versions, and add unit tests.