### PR TITLE
Enable Ruby 3.2's YJIT by default for new projects

### DIFF
--- a/docs/tutorials/deploying-rails-from-scratch.md
+++ b/docs/tutorials/deploying-rails-from-scratch.md
@@ -40,8 +40,27 @@ Rails requires certain operating system packages in order to build Ruby and inst
 ```sh
 # Run these commands as root on the VPS
 apt-get -y update
-apt-get -y install build-essential pkg-config git-core curl locales \
-                   libffi-dev libreadline-dev libsqlite3-dev libssl-dev libyaml-dev \
+apt-get -y install autoconf \
+                   bison \
+                   build-essential \
+                   curl \
+                   git-core \
+                   libdb-dev \
+                   libffi-dev \
+                   libgdbm-dev \
+                   libgdbm6 \
+                   libgmp-dev \
+                   libncurses5-dev \
+                   libreadline6-dev \
+                   libsqlite3-dev \
+                   libssl-dev \
+                   libyaml-dev \
+                   locales \
+                   patch \
+                   pkg-config \
+                   rustc \
+                   uuid-dev \
+                   zlib1g-dev \
                    tzdata
 locale-gen en_US.UTF-8
 ```

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -33,6 +33,7 @@ set env_vars: {
   RAILS_ENV: "production",
   RAILS_LOG_TO_STDOUT: "1",
   RAILS_SERVE_STATIC_FILES: "1",
+  RUBY_YJIT_ENABLE: "1",
   BOOTSNAP_CACHE_DIR: "tmp/bootsnap-cache",
   DATABASE_URL: :prompt,
   SECRET_KEY_BASE: :prompt

--- a/lib/tomo/testing/ubuntu_setup.sh
+++ b/lib/tomo/testing/ubuntu_setup.sh
@@ -17,8 +17,27 @@ touch /var/lib/systemd/linger/deployer
 
 # Packages needed for ruby, etc.
 apt-get -y update
-apt-get -y install build-essential pkg-config git-core curl locales \
-                   libffi-dev libreadline-dev libsqlite3-dev libssl-dev libyaml-dev zlib1g-dev
+apt-get -y install autoconf \
+                   bison \
+                   build-essential \
+                   curl \
+                   git-core \
+                   libdb-dev \
+                   libffi-dev \
+                   libgdbm-dev \
+                   libgdbm6 \
+                   libgmp-dev \
+                   libncurses5-dev \
+                   libreadline6-dev \
+                   libsqlite3-dev \
+                   libssl-dev \
+                   libyaml-dev \
+                   locales \
+                   patch \
+                   pkg-config \
+                   rustc \
+                   uuid-dev \
+                   zlib1g-dev
 
 apt-get -y install tzdata \
         -o DPkg::options::="--force-confdef" \


### PR DESCRIPTION
- Building Ruby 3.2 with YJIT support requires the `rustc` package
- YJIT can be enabled by setting the `RUBY_YJIT_ENABLE=1` env var

This commit also adds all other Ubuntu packages recommended by the ruby-build documentation.