### PR TITLE
Fix bug where `nodenv:install` would fail during `--dry-run`

### DIFF
--- a/lib/tomo/plugin/nodenv/tasks.rb
+++ b/lib/tomo/plugin/nodenv/tasks.rb
@@ -62,6 +62,8 @@ module Tomo::Plugin::Nodenv
       version = remote.capture("cat", path, raise_on_error: false).strip
       return version unless version.empty?
 
+      return "DRY_RUN_PLACEHOLDER" if dry_run?
+
       die <<~REASON
         Could not guess node version from .node-version file.
         Use the :nodenv_node_version setting to specify the version of node to install.

--- a/lib/tomo/ssh.rb
+++ b/lib/tomo/ssh.rb
@@ -17,12 +17,16 @@ module Tomo
         options = Options.new(options) unless options.is_a?(Options)
 
         Tomo.logger.connect(host)
-        return Connection.dry_run(host, options) if Tomo.dry_run?
+        return build_dry_run_connection(host, options) if Tomo.dry_run?
 
         build_connection(host, options)
       end
 
       private
+
+      def build_dry_run_connection(host, options)
+        Connection.dry_run(host, options)
+      end
 
       def build_connection(host, options)
         conn = Connection.new(host, options)

--- a/lib/tomo/testing/host_extensions.rb
+++ b/lib/tomo/testing/host_extensions.rb
@@ -20,6 +20,8 @@ module Tomo
 
       def result_for(script)
         match = mocks.find { |regexp, _| regexp.match?(script.to_s) }
+        raise "Scripts cannot be mocked during dry_run" if match && Tomo.dry_run?
+
         match&.last || Result.empty_success
       end
     end

--- a/lib/tomo/testing/ssh_extensions.rb
+++ b/lib/tomo/testing/ssh_extensions.rb
@@ -3,6 +3,12 @@ module Tomo
     module SSHExtensions
       private
 
+      def build_dry_run_connection(host, options)
+        return super if Testing.ssh_enabled
+
+        Testing::Connection.new(host, options)
+      end
+
       def build_connection(host, options)
         return super if Testing.ssh_enabled
 

--- a/test/tomo/plugin/nodenv/tasks_test.rb
+++ b/test/tomo/plugin/nodenv/tasks_test.rb
@@ -97,6 +97,15 @@ class Tomo::Plugin::Nodenv::TasksTest < Minitest::Test
     assert_includes(tester.executed_scripts, "nodenv install 16.15.0")
   end
 
+  def test_install_uses_a_placeholder_node_version_during_dry_run_so_it_runs_without_error
+    Tomo.dry_run = true
+    tester = configure(release_path: "/tmp/tomo/20201027184921")
+    tester.run_task("nodenv:install")
+    assert_includes(tester.executed_scripts, "nodenv install DRY_RUN_PLACEHOLDER")
+  ensure
+    Tomo.dry_run = false
+  end
+
   private
 
   def configure(settings={})


### PR DESCRIPTION
When `nodenv:install` tries to guess what Node version to use, it attempts to read a `.node-version` file. This doesn't work in a `--dry-run`, because no SSH I/O occurs and the file is not actually read. As a result, a dry run would lead to this error:

> Could not guess node version from .node-version file.
Use the :nodenv_node_version setting to specify the version of node to install.

Fix by using a placeholder node version in the dry run scenario.

This PR introduces tomo's first dry-run unit test, so a little extra test support code was also added to make this type of test possible.