### PR TITLE
Improve security of env variables by narrowing envrc permissions

### DIFF
--- a/lib/tomo/plugin/env/tasks.rb
+++ b/lib/tomo/plugin/env/tasks.rb
@@ -62,6 +62,7 @@ module Tomo::Plugin::Env
 
       remote.mkdir_p(paths.env.dirname) if original.empty?
       remote.write(text: env, to: paths.env)
+      remote.run("chmod", "600", paths.env) if original.empty?
     end
 
     def read_existing

--- a/test/tomo/plugin/env/tasks_test.rb
+++ b/test/tomo/plugin/env/tasks_test.rb
@@ -79,4 +79,19 @@ class Tomo::Plugin::Env::TasksTest < Minitest::Test
     assert_match("only one application can be deployed", error.message)
     assert_match("/var/www/oldapp/envrc", error.message)
   end
+
+  def test_executes_chmod_to_reduce_visibility_of_envrc_file_upon_creation
+    tester = Tomo::Testing::MockPluginTester.new(
+      "env",
+      settings: {
+        env_path: "/app/envrc",
+        env_vars: {
+          RAILS_ENV: "production",
+          RAILS_MAX_THREADS: 6
+        }
+      }
+    )
+    tester.run_task("env:setup")
+    assert_equal("chmod 600 /app/envrc", tester.executed_scripts.last)
+  end
 end


### PR DESCRIPTION
Tomo stores environment variables (configured through the `env:` tasks) in an `envrc` file. Before this PR, that file had default permissions. On many systems, this could mean the file would be world-readable by any user by default.

This PR improves the security of tomo-managed environment variables by calling `chmod 600` when initially creating the `envrc` file.

For existing tomo deployments, you may want to manually check the permissions of the `envrc` file and change them if necessary.