### PR TITLE
Hide gem post-install messages by default

### DIFF
--- a/docs/plugins/bundler.md
+++ b/docs/plugins/bundler.md
@@ -6,16 +6,17 @@ The bundler plugin installs ruby gem dependencies using bundler. This is require
 
 Note that the settings listed here only take effect if you run the [bundler:config](#bundlerconfig) task.
 
-| Name                  | Purpose                                                                                                                                                                       | Default                   |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| `bundler_config_path` | Location where the [bundler:config](#bundlerconfig) task will write bundler's configuration file                                                                              | `".bundle/config"`        |
-| `bundler_deployment`  | Enables bundler's [deployment mode](https://bundler.io/v2.0/man/bundle-install.1.html#DEPLOYMENT-MODE) (strongly recommended)                                                 | `true`                    |
-| `bundler_gemfile`     | Optionally used to override the location of the Gemfile                                                                                                                       | `nil`                     |
-| `bundler_jobs`        | Override bundler's default (number of processors) amount of concurrency used when downloading/installing gems                                                                 | `nil`                     |
-| `bundler_path`        | Directory where gems where be installed                                                                                                                                       | `"%{shared_path}/bundle"` |
-| `bundler_retry`       | Number of times to retry installing a gem if it fails to download                                                                                                             | `"3"`                     |
-| `bundler_version`     | The version of bundler to install, used by the [bundler:upgrade_bundler](#bundlerupgrade_bundler) task; if `nil` (the default), determine the version based on `Gemfile.lock` | `nil`                     |
-| `bundler_without`     | Array of Gemfile groups to exclude from installation                                                                                                                          | `["development", "test"]` |
+| Name                      | Purpose                                                                                                                                                                       | Default                   |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `bundler_config_path`     | Location where the [bundler:config](#bundlerconfig) task will write bundler's configuration file                                                                              | `".bundle/config"`        |
+| `bundler_deployment`      | Enables bundler's [deployment mode](https://bundler.io/v2.0/man/bundle-install.1.html#DEPLOYMENT-MODE) (strongly recommended)                                                 | `true`                    |
+| `bundler_gemfile`         | Optionally used to override the location of the Gemfile                                                                                                                       | `nil`                     |
+| `bundler_ignore_messages` | Hide gem post-install messages during `bundle install`                                                                                                                        | `true`                    |
+| `bundler_jobs`            | Override bundler's default (number of processors) amount of concurrency used when downloading/installing gems                                                                 | `nil`                     |
+| `bundler_path`            | Directory where gems where be installed                                                                                                                                       | `"%{shared_path}/bundle"` |
+| `bundler_retry`           | Number of times to retry installing a gem if it fails to download                                                                                                             | `"3"`                     |
+| `bundler_version`         | The version of bundler to install, used by the [bundler:upgrade_bundler](#bundlerupgrade_bundler) task; if `nil` (the default), determine the version based on `Gemfile.lock` | `nil`                     |
+| `bundler_without`         | Array of Gemfile groups to exclude from installation                                                                                                                          | `["development", "test"]` |
 
 ## Tasks
 

--- a/lib/tomo/plugin/bundler.rb
+++ b/lib/tomo/plugin/bundler.rb
@@ -8,13 +8,14 @@ module Tomo::Plugin
     tasks Tomo::Plugin::Bundler::Tasks
     helpers Tomo::Plugin::Bundler::Helpers
 
-    defaults bundler_config_path: ".bundle/config",
-             bundler_deployment:  true,
-             bundler_gemfile:     nil,
-             bundler_jobs:        nil,
-             bundler_path:        "%{shared_path}/bundle",
-             bundler_retry:       "3",
-             bundler_version:     nil,
-             bundler_without:     %w[development test]
+    defaults bundler_config_path:     ".bundle/config",
+             bundler_deployment:      true,
+             bundler_gemfile:         nil,
+             bundler_ignore_messages: true,
+             bundler_jobs:            nil,
+             bundler_path:            "%{shared_path}/bundle",
+             bundler_retry:           "3",
+             bundler_version:         nil,
+             bundler_without:         %w[development test]
   end
 end

--- a/lib/tomo/plugin/bundler/tasks.rb
+++ b/lib/tomo/plugin/bundler/tasks.rb
@@ -5,6 +5,7 @@ module Tomo::Plugin::Bundler
     CONFIG_SETTINGS = %i[
       bundler_deployment
       bundler_gemfile
+      bundler_ignore_messages
       bundler_jobs
       bundler_path
       bundler_retry

--- a/test/tomo/plugin/bundler/tasks_test.rb
+++ b/test/tomo/plugin/bundler/tasks_test.rb
@@ -20,6 +20,7 @@ class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
       bundler_config_path: ".bundle/config",
       bundler_deployment: true,
       bundler_gemfile: "Gemfile.prod",
+      bundler_ignore_messages: true,
       bundler_jobs: 12,
       bundler_path: "/app/bundle",
       bundler_retry: 2,
@@ -32,6 +33,7 @@ class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
       echo -n ---'
       'BUNDLE_DEPLOYMENT:\ \'true\''
       'BUNDLE_GEMFILE:\ Gemfile.prod'
+      'BUNDLE_IGNORE_MESSAGES:\ \'true\''
       'BUNDLE_JOBS:\ \'12\''
       'BUNDLE_PATH:\ \"/app/bundle\"'
       'BUNDLE_RETRY:\ \'2\''
@@ -45,6 +47,7 @@ class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
       bundler_config_path: ".bundle/config",
       bundler_deployment: false,
       bundler_gemfile: nil,
+      bundler_ignore_messages: false,
       bundler_jobs: nil,
       bundler_path: "/app/bundle",
       bundler_retry: nil,
@@ -55,6 +58,7 @@ class Tomo::Plugin::Bundler::TasksTest < Minitest::Test
     assert_equal(<<~'SCRIPT'.strip, tester.executed_scripts.last)
       echo -n ---'
       'BUNDLE_DEPLOYMENT:\ \'false\''
+      'BUNDLE_IGNORE_MESSAGES:\ \'false\''
       'BUNDLE_PATH:\ \"/app/bundle\"'
       ' > .bundle/config
     SCRIPT


### PR DESCRIPTION
When `bundle install` is run as part of the setup or deploy process, each gem has an opportunity to display a post-install message. These messages are mostly noise, especially for a deployment tool like tomo.

This PR changes the default bundler config that is generated by tomo to set the `BUNDLE_IGNORE_MESSAGES` option. This means that applications deployed by tomo will now hide gem post-install messages by default.

To adopt this new default, run the `bundler:setup` task to update the bundler config file:

```sh
tomo run bundler:setup
```

If you want to restore tomo's old behavior, and show post-install messages, then add this setting to your `.tomo/config.rb`:

```ruby
set bundler_ignore_messages: false
```

and then re-run `bundler:setup`.