### PR TITLE
More reliably guess the right git_branch when generating .tomo/config.rb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - run: git config --global user.name 'github-actions[bot]'
+      - run: git config --global user.email 'github-actions[bot]@users.noreply.github.com'
       - run: bundle exec rake test
   test_rails_deploy:
     name: "Test / Rails Deploy"

--- a/lib/tomo/commands/init.rb
+++ b/lib/tomo/commands/init.rb
@@ -71,10 +71,22 @@ module Tomo
         nil
       end
 
-      def git_branch
+      def git_main_branch
         return unless File.file?(".git/config")
 
-        `git rev-parse --abbrev-ref HEAD`.chomp
+        # If "main" or "master" is in the list of branch names, use that
+        branch = (%w[main master] & `git branch`.scan(/^\W*(.+)$/).flatten).first
+
+        # If not, use the current branch
+        if branch.nil?
+          branch = if `git --version`[/\d+\.\d+/].to_f >= 2.22
+                     `git branch --show-current`.chomp
+                   else
+                     `git rev-parse --abbrev-ref HEAD`.chomp
+                   end
+        end
+
+        branch.empty? ? nil : branch
       rescue SystemCallError
         nil
       end

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -22,7 +22,7 @@ set nodenv_node_version: <%= node_version&.inspect || "nil # FIXME" %>
 <% end -%>
 set nodenv_install_yarn: <%= yarn_version ? "true" : "false" %>
 set git_url: <%= git_origin_url&.inspect || "nil # FIXME" %>
-set git_branch: <%= git_branch&.inspect || "nil # FIXME" %>
+set git_branch: <%= git_main_branch&.inspect || "nil # FIXME" %>
 set git_exclusions: %w[
   .tomo/
   spec/


### PR DESCRIPTION
This PR improves how `tomo init` fills in the default `git_branch` value in the generated `.tomo/config.rb` file.

**Improved behavior on new, empty git repos**

Before, when `tomo init` was run on a brand new git repo that does not yet have any commits, a confusing message would be printed to stderr and tomo would fail to fill in the `git_branch` setting in the generated `.tomo/config.rb` file:

```
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Now, `tomo init` will use the `git branch --show-current` command (available in git 2.22 and newer) to determine the current branch name. This command works even for a git repo that does not yet have any commits. In this case git returns the default branch name. For example, this will usually resolve to `main`.

**Improved behavior on feature branches**

When adding tomo to an existing project, developers will often be working on a feature branch, not their main branch.

Before, `tomo init` would always use the current branch name when filling in the default `git_branch` setting. This is not usually what you want, because feature branches are short-lived.

Now, `tomo init` will try to guess the main branch name and use that instead. It checks if either `main` or `master` exists, and if so, it will use that for the default `git_branch` setting. Otherwise, it will fall back to the existing behavior of using the current branch name.