### PR TITLE
Include doc link in sample plugin generated by `tomo init`

### DIFF
--- a/lib/tomo/commands/init.rb
+++ b/lib/tomo/commands/init.rb
@@ -30,11 +30,9 @@ module Tomo
 
         app = args.first || current_dir_name || "default"
         app = app.gsub(/([^\w-]|_)+/, "_").downcase
+
         FileUtils.mkdir_p(".tomo/plugins")
-
-        # TODO: use a template for this file
-        FileUtils.touch(".tomo/plugins/#{app}.rb")
-
+        File.write(".tomo/plugins/#{app}.rb", plugin_rb_template)
         File.write(DEFAULT_CONFIG_PATH, config_rb_template(app))
 
         logger.info(green("✔ Created #{DEFAULT_CONFIG_PATH}"))
@@ -128,6 +126,12 @@ module Tomo
 
       def config_rb_template(app)
         path = File.expand_path("../templates/config.rb.erb", __dir__)
+        template = File.read(path)
+        ERB.new(template, trim_mode: "-").result(binding)
+      end
+
+      def plugin_rb_template
+        path = File.expand_path("../templates/plugin.rb.erb", __dir__)
         template = File.read(path)
         ERB.new(template, trim_mode: "-").result(binding)
       end

--- a/lib/tomo/templates/plugin.rb.erb
+++ b/lib/tomo/templates/plugin.rb.erb
@@ -1,0 +1,1 @@
+# https://tomo-deploy.com/tutorials/writing-custom-tasks/

--- a/test/tomo/commands/init_test.rb
+++ b/test/tomo/commands/init_test.rb
@@ -68,6 +68,15 @@ class Tomo::Commands::InitTest < Minitest::Test
     end
   end
 
+  def test_generates_a_sample_plugin_with_comment
+    @tester.in_temp_dir do
+      @tester.run "init"
+
+      app = File.basename(File.expand_path("."))
+      assert_match(%r{^# https://tomo-deploy.com}, File.read(".tomo/plugins/#{app}.rb"))
+    end
+  end
+
   private
 
   def with_backtick_stub(command, result)


### PR DESCRIPTION
Before, `tomo init` would generate a sample plugin file, but that file was empty with no explanation. This PR adds a comment to the sample plugin file that `tomo init` generates, so that:

- Users know where to find more information about writing plugins
- Rubocop doesn't complain about the fact that the file is empty

This also fixes a `TODO` in `init.rb`.