### PR TITLE
Add abbrev dependency to fix warning on Ruby 3.3

### DIFF
--- a/tomo.gemspec
+++ b/tomo.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_dependency "abbrev"
 end


### PR DESCRIPTION
Fixes the following warning on Ruby 3.3.0:

> abbrev was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add abbrev to your Gemfile or gemspec.
