### PR TITLE
Remove `abbrev` dependency

### DIFF
--- a/lib/tomo/cli.rb
+++ b/lib/tomo/cli.rb
@@ -1,5 +1,3 @@
-require "abbrev"
-
 module Tomo
   class CLI
     autoload :Command, "tomo/cli/command"
@@ -63,12 +61,19 @@ module Tomo
       commands = COMMANDS.merge(COMMAND_ALIASES)
 
       command_name = argv.first unless Completions.active? && argv.length == 1
-      command_name = Abbrev.abbrev(commands.keys)[command_name]
+      command_name = expand_abbrev(commands.keys, command_name)
       argv.shift if command_name
 
       command_name = "run" if command_name.nil? && task_format?(argv.first)
       command = commands[command_name] || Tomo::Commands::Default
       [command, command_name]
+    end
+
+    def expand_abbrev(names, abbrev)
+      return nil if abbrev.to_s.empty?
+
+      matches = names.select { |name| name.start_with?(abbrev) }
+      matches.first if matches.one?
     end
 
     def task_format?(arg)

--- a/test/tomo/cli_test.rb
+++ b/test/tomo/cli_test.rb
@@ -11,6 +11,14 @@ class Tomo::CLITest < Minitest::Test
     assert_match "Simulated bundler:install", @tester.stdout
   end
 
+  def test_commands_can_be_abbreviated
+    stdout, = capture_io { @tester.run "i", "--help" }
+    assert_match "Usage: tomo init", stdout
+
+    stdout, = capture_io { @tester.run "d", "--help" }
+    assert_match "Usage: tomo deploy", stdout
+  end
+
   def test_dash_t_is_alias_for_tasks
     @tester.run "init"
     @tester.run "-T"

--- a/tomo.gemspec
+++ b/tomo.gemspec
@@ -31,6 +31,4 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  spec.add_dependency "abbrev"
 end


### PR DESCRIPTION
Our use of the `abbrev` gem is simple enough that we can replace it with our own simple implementation. This eliminates the gem dependency so that tomo can continue to have "minimal dependencies", as advertised in the README.