### PR TITLE
Remove unnecessary env vars from suggested config

### DIFF
--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -29,10 +29,7 @@ set git_exclusions: %w[
   test/
 ]
 set env_vars: {
-  RACK_ENV: "production",
   RAILS_ENV: "production",
-  RAILS_LOG_TO_STDOUT: "1",
-  RAILS_SERVE_STATIC_FILES: "1",
   RUBY_YJIT_ENABLE: "1",
   BOOTSNAP_CACHE_DIR: "tmp/bootsnap-cache",
   DATABASE_URL: :prompt,


### PR DESCRIPTION
- `RACK_ENV` is not strictly needed; `RAILS_ENV` is enough
- `RAILS_LOG_TO_STDOUT` and `RAILS_SERVE_STATIC_ASSETS` are no longer used in newly generated Rails apps