### PR TITLE
Auto-generate env var values, e.g for `SECRET_KEY_BASE`

### DIFF
--- a/docs/plugins/env.md
+++ b/docs/plugins/env.md
@@ -44,10 +44,12 @@ export RAILS_ENV=production
 export PUMA_THREADS=20
 ```
 
-For environment variables that are used for secrets or other sensitive data, you can specify `:prompt` instead of the actual value. In this case tomo will prompt interactively for the value the first time it is needed. For example:
+#### `:prompt`
+
+For environment variables that are used for API keys or other sensitive data, you can specify `:prompt` instead of the actual value. In this case tomo will prompt interactively for the value the first time it is needed. For example:
 
 ```ruby
-set env_vars: { SECRET_KEY_BASE: :prompt }
+set env_vars: { DATABASE_URL: :prompt }
 ```
 
 The first time `env:update` is run, tomo will prompt for the value:
@@ -57,10 +59,18 @@ $ tomo deploy
 tomo deploy v1.0.0
 → Connecting to user@app.example.com
 • env:update
-SECRET_KEY_BASE?
+DATABASE_URL?
 ```
 
 Once the environment variable exists in the envrc file, tomo will no longer prompt for it.
+
+#### `:generate_secret`
+
+Similarly, for environment variables that requires a randomly generated secret value, like `SECRET_KEY_BASE`, you can specify `:generate_secret`. In this case, tomo will generate a value using `SecureRandom.hex(64)` the first time it is needed.
+
+```ruby
+set env_vars: { SECRET_KEY_BASE: :generate_secret }
+```
 
 `env:update` is intended for use as a [deploy](../commands/deploy.md) task. It should be run at the beginning of a deploy to ensure that the environment has all the latest values before other tasks are run.
 

--- a/docs/tutorials/deploying-rails-from-scratch.md
+++ b/docs/tutorials/deploying-rails-from-scratch.md
@@ -141,10 +141,7 @@ Tomo comes with a `setup` command that will prepare your VPS for its first deplo
 $ tomo setup
 ```
 
-You will be asked for two environment variables. Tomo will store these values on the VPS so that you only have to provide them once:
-
-- **DATABASE_URL** is needed to tell Rails how to connect to the database. The basic app we are deploying uses sqlite. Provide this value when prompted: `sqlite3:/var/www/rails-new/shared/production.sqlite3`. This will store the database in a shared location so that it doesn't change from release to release.
-- **SECRET_KEY_BASE** is needed by all Rails apps to securely encrypt session cookies and other important data. Run `ruby -rsecurerandom -e "puts SecureRandom.hex(64)"` to generate an appropriate value.
+You will be asked to specify a value for the **DATABASE_URL** environment variable. Tomo will store this value on the VPS so that you only have to provide it once. Provide this value when prompted: `sqlite3:/var/www/rails-new/shared/production.sqlite3`.
 
 Note that `tomo setup` compiles Ruby from source, which will take several minutes.
 

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -36,7 +36,7 @@ set env_vars: {
   RUBY_YJIT_ENABLE: "1",
   BOOTSNAP_CACHE_DIR: "tmp/bootsnap-cache",
   DATABASE_URL: :prompt,
-  SECRET_KEY_BASE: :prompt
+  SECRET_KEY_BASE: :generate_secret
 }
 set linked_dirs: %w[
   .yarn/cache

--- a/test/e2e/rails_setup_deploy_e2e_test.rb
+++ b/test/e2e/rails_setup_deploy_e2e_test.rb
@@ -16,7 +16,7 @@ class RailsSetupDeployE2ETest < Minitest::Test
   end
 
   def test_rails_setup_deploy
-    in_cloned_rails_repo do # rubocop:disable Metrics/BlockLength
+    in_cloned_rails_repo do
       bundle_exec("tomo init")
       config = File.read(".tomo/config.rb")
       config.sub!(
@@ -32,11 +32,7 @@ class RailsSetupDeployE2ETest < Minitest::Test
       CONFIG
       File.write(".tomo/config.rb", config)
 
-      bundle_exec(
-        "tomo run env:set " \
-        "DATABASE_URL=sqlite3:/var/www/rails-new/shared/production.sqlite3 " \
-        "SECRET_KEY_BASE=#{SecureRandom.hex(64)}"
-      )
+      bundle_exec("tomo run env:set DATABASE_URL=sqlite3:/var/www/rails-new/shared/production.sqlite3")
       bundle_exec("tomo setup")
       bundle_exec("tomo deploy")
 


### PR DESCRIPTION
When specifying `:env_vars` in the tomo config file, you can now use a special `:generate_secret` value. This will automatically generate a secret using `SecureRandom.hex(64)` the first time it is needed.

The tomo configuration template created by `tomo init` now includes this env var value:

```
SECRET_KEY_BASE: :generate_secret
```

This means that the first time the app is deployed, an appropriate value for `SECRET_KEY_BASE` will be generated automatically, without prompting the user.