### PR TITLE
Opt into Ruby frozen string literals throughout the codebase

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,9 +111,6 @@ Style/FetchEnvVar:
 Style/FormatStringToken:
   Enabled: false
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 Style/NumericLiterals:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rake/testtask"
 require "rubocop/rake_task"

--- a/exe/tomo
+++ b/exe/tomo
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "tomo"
 Tomo::CLI.new.call(ARGV)

--- a/lib/tomo.rb
+++ b/lib/tomo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   autoload :CLI, "tomo/cli"
   autoload :Colors, "tomo/colors"
@@ -21,7 +23,7 @@ module Tomo
   autoload :TaskLibrary, "tomo/task_library"
   autoload :VERSION, "tomo/version"
 
-  DEFAULT_CONFIG_PATH = ".tomo/config.rb".freeze
+  DEFAULT_CONFIG_PATH = ".tomo/config.rb"
 
   class << self
     attr_accessor :logger

--- a/lib/tomo/cli.rb
+++ b/lib/tomo/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     autoload :Command, "tomo/cli/command"

--- a/lib/tomo/cli/command.rb
+++ b/lib/tomo/cli/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     class Command

--- a/lib/tomo/cli/common_options.rb
+++ b/lib/tomo/cli/common_options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     module CommonOptions

--- a/lib/tomo/cli/completions.rb
+++ b/lib/tomo/cli/completions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     class Completions

--- a/lib/tomo/cli/deploy_options.rb
+++ b/lib/tomo/cli/deploy_options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     module DeployOptions

--- a/lib/tomo/cli/error.rb
+++ b/lib/tomo/cli/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     class Error < ::Tomo::Error

--- a/lib/tomo/cli/interrupted_error.rb
+++ b/lib/tomo/cli/interrupted_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     class InterruptedError < Error

--- a/lib/tomo/cli/options.rb
+++ b/lib/tomo/cli/options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     class Options

--- a/lib/tomo/cli/parser.rb
+++ b/lib/tomo/cli/parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 
 module Tomo

--- a/lib/tomo/cli/project_options.rb
+++ b/lib/tomo/cli/project_options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     module ProjectOptions

--- a/lib/tomo/cli/rules.rb
+++ b/lib/tomo/cli/rules.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     class Rules

--- a/lib/tomo/cli/rules/argument.rb
+++ b/lib/tomo/cli/rules/argument.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Tomo::CLI::Rules
   class Argument
     def initialize(label, values_proc:, multiple: false, required: false)

--- a/lib/tomo/cli/rules/switch.rb
+++ b/lib/tomo/cli/rules/switch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Tomo::CLI::Rules
   class Switch
     def initialize(key, *switches, callback_proc:, required: false, &convert_proc)

--- a/lib/tomo/cli/rules/value_switch.rb
+++ b/lib/tomo/cli/rules/value_switch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Tomo::CLI::Rules
   class ValueSwitch < Switch
     include Tomo::Colors

--- a/lib/tomo/cli/rules_evaluator.rb
+++ b/lib/tomo/cli/rules_evaluator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     class RulesEvaluator

--- a/lib/tomo/cli/state.rb
+++ b/lib/tomo/cli/state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     class State

--- a/lib/tomo/cli/usage.rb
+++ b/lib/tomo/cli/usage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class CLI
     class Usage

--- a/lib/tomo/colors.rb
+++ b/lib/tomo/colors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Colors
     ANSI_CODES = {

--- a/lib/tomo/commands.rb
+++ b/lib/tomo/commands.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Commands
     autoload :CompletionScript, "tomo/commands/completion_script"

--- a/lib/tomo/commands/completion_script.rb
+++ b/lib/tomo/commands/completion_script.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Commands
     class CompletionScript

--- a/lib/tomo/commands/default.rb
+++ b/lib/tomo/commands/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Commands
     class Default < CLI::Command

--- a/lib/tomo/commands/deploy.rb
+++ b/lib/tomo/commands/deploy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Commands
     class Deploy < CLI::Command

--- a/lib/tomo/commands/help.rb
+++ b/lib/tomo/commands/help.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Commands
     class Help

--- a/lib/tomo/commands/init.rb
+++ b/lib/tomo/commands/init.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "erb"
 require "fileutils"
 

--- a/lib/tomo/commands/run.rb
+++ b/lib/tomo/commands/run.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Commands
     class Run < CLI::Command

--- a/lib/tomo/commands/setup.rb
+++ b/lib/tomo/commands/setup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Commands
     class Setup < CLI::Command

--- a/lib/tomo/commands/tasks.rb
+++ b/lib/tomo/commands/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Commands
     class Tasks < CLI::Command

--- a/lib/tomo/commands/version.rb
+++ b/lib/tomo/commands/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Commands
     class Version < CLI::Command

--- a/lib/tomo/configuration.rb
+++ b/lib/tomo/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     autoload :DSL, "tomo/configuration/dsl"

--- a/lib/tomo/configuration/dsl.rb
+++ b/lib/tomo/configuration/dsl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     module DSL

--- a/lib/tomo/configuration/dsl/batch_block.rb
+++ b/lib/tomo/configuration/dsl/batch_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     module DSL

--- a/lib/tomo/configuration/dsl/config_file.rb
+++ b/lib/tomo/configuration/dsl/config_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     module DSL

--- a/lib/tomo/configuration/dsl/environment_block.rb
+++ b/lib/tomo/configuration/dsl/environment_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     module DSL

--- a/lib/tomo/configuration/dsl/error_formatter.rb
+++ b/lib/tomo/configuration/dsl/error_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     module DSL

--- a/lib/tomo/configuration/dsl/error_formatter.rb
+++ b/lib/tomo/configuration/dsl/error_formatter.rb
@@ -57,7 +57,7 @@ module Tomo
           last = [dsl_lines.length, error_line_no + 1].min
           width = last.to_s.length
 
-          (first..last).each_with_object("") do |line_no, result|
+          (first..last).each_with_object(+"") do |line_no, result|
             line = dsl_lines[line_no - 1]
             line_no_prefix = line_no.to_s.rjust(width)
 

--- a/lib/tomo/configuration/dsl/hosts_and_settings.rb
+++ b/lib/tomo/configuration/dsl/hosts_and_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     module DSL

--- a/lib/tomo/configuration/dsl/tasks_block.rb
+++ b/lib/tomo/configuration/dsl/tasks_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     module DSL

--- a/lib/tomo/configuration/environment.rb
+++ b/lib/tomo/configuration/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     class Environment

--- a/lib/tomo/configuration/glob.rb
+++ b/lib/tomo/configuration/glob.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     class Glob

--- a/lib/tomo/configuration/plugin_file_not_found_error.rb
+++ b/lib/tomo/configuration/plugin_file_not_found_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     class PluginFileNotFoundError < Error

--- a/lib/tomo/configuration/plugins_registry.rb
+++ b/lib/tomo/configuration/plugins_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     class PluginsRegistry

--- a/lib/tomo/configuration/plugins_registry/file_resolver.rb
+++ b/lib/tomo/configuration/plugins_registry/file_resolver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     class PluginsRegistry::FileResolver

--- a/lib/tomo/configuration/plugins_registry/gem_resolver.rb
+++ b/lib/tomo/configuration/plugins_registry/gem_resolver.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     class PluginsRegistry::GemResolver
-      PLUGIN_PREFIX = "tomo/plugin".freeze
+      PLUGIN_PREFIX = "tomo/plugin"
       private_constant :PLUGIN_PREFIX
 
       def self.resolve(name)

--- a/lib/tomo/configuration/project_not_found_error.rb
+++ b/lib/tomo/configuration/project_not_found_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     class ProjectNotFoundError < Tomo::Error

--- a/lib/tomo/configuration/role_based_task_filter.rb
+++ b/lib/tomo/configuration/role_based_task_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     class RoleBasedTaskFilter

--- a/lib/tomo/configuration/unknown_environment_error.rb
+++ b/lib/tomo/configuration/unknown_environment_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     class UnknownEnvironmentError < Tomo::Error

--- a/lib/tomo/configuration/unknown_environment_error.rb
+++ b/lib/tomo/configuration/unknown_environment_error.rb
@@ -25,10 +25,10 @@ module Tomo
         ERROR
 
         if suggestions.any?
-          error << suggestions.to_console
+          error + suggestions.to_console
         else
           envs = known_environments.map { |env| blue("  #{env}") }
-          error << <<~ENVS
+          error + <<~ENVS
 
             The following environments are available:
 

--- a/lib/tomo/configuration/unknown_plugin_error.rb
+++ b/lib/tomo/configuration/unknown_plugin_error.rb
@@ -11,9 +11,9 @@ module Tomo
         ERROR
 
         sugg = Error::Suggestions.new(dictionary: known_plugins, word: name)
-        error << sugg.to_console if sugg.any?
+        error += sugg.to_console if sugg.any?
 
-        error << gem_suggestion
+        error + gem_suggestion
       end
 
       private

--- a/lib/tomo/configuration/unknown_plugin_error.rb
+++ b/lib/tomo/configuration/unknown_plugin_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     class UnknownPluginError < Tomo::Error

--- a/lib/tomo/configuration/unspecified_environment_error.rb
+++ b/lib/tomo/configuration/unspecified_environment_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Configuration
     class UnspecifiedEnvironmentError < Tomo::Error

--- a/lib/tomo/console.rb
+++ b/lib/tomo/console.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 require "io/console"
 

--- a/lib/tomo/console/key_reader.rb
+++ b/lib/tomo/console/key_reader.rb
@@ -37,7 +37,7 @@ module Tomo
       end
 
       def read_chars_nonblock
-        chars = ""
+        chars = +""
         loop do
           next_char = raw { read_nonblock(1) }
           break if next_char.nil?

--- a/lib/tomo/console/key_reader.rb
+++ b/lib/tomo/console/key_reader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 require "io/console"
 require "time"

--- a/lib/tomo/console/menu.rb
+++ b/lib/tomo/console/menu.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 require "forwardable"
 require "io/console"
 
 module Tomo
   class Console
     class Menu
-      ARROW_UP = "\e[A".freeze
-      ARROW_DOWN = "\e[B".freeze
-      RETURN = "\r".freeze
-      ENTER = "\n".freeze
+      ARROW_UP = "\e[A"
+      ARROW_DOWN = "\e[B"
+      RETURN = "\r"
+      ENTER = "\n"
 
       extend Forwardable
       include Colors

--- a/lib/tomo/console/non_interactive_error.rb
+++ b/lib/tomo/console/non_interactive_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Console
     class NonInteractiveError < Tomo::Error

--- a/lib/tomo/console/non_interactive_error.rb
+++ b/lib/tomo/console/non_interactive_error.rb
@@ -7,8 +7,8 @@ module Tomo
 
       def to_console
         error = ""
-        error << "#{operation_name} requires an interactive console."
-        error << "\n\n#{seems_like_ci}" if ci_var
+        error += "#{operation_name} requires an interactive console."
+        error += "\n\n#{seems_like_ci}" if ci_var
         error
       end
 

--- a/lib/tomo/error.rb
+++ b/lib/tomo/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Error < StandardError
     autoload :Suggestions, "tomo/error/suggestions"

--- a/lib/tomo/error/suggestions.rb
+++ b/lib/tomo/error/suggestions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Error
     class Suggestions

--- a/lib/tomo/host.rb
+++ b/lib/tomo/host.rb
@@ -33,7 +33,7 @@ module Tomo
 
     def to_s
       str = user ? "#{user}@#{address}" : address
-      str << ":#{port}" unless port == 22
+      str += ":#{port}" unless port == 22
       str
     end
 

--- a/lib/tomo/host.rb
+++ b/lib/tomo/host.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Host
     PATTERN = /^(?:(\S+)@)?(\S*?)$/

--- a/lib/tomo/logger.rb
+++ b/lib/tomo/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 
 module Tomo

--- a/lib/tomo/logger/tagged_io.rb
+++ b/lib/tomo/logger/tagged_io.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Logger
     class TaggedIO

--- a/lib/tomo/path.rb
+++ b/lib/tomo/path.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "delegate"
 require "pathname"
 

--- a/lib/tomo/paths.rb
+++ b/lib/tomo/paths.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Paths
     def initialize(settings)

--- a/lib/tomo/plugin.rb
+++ b/lib/tomo/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Plugin
   end

--- a/lib/tomo/plugin/bundler.rb
+++ b/lib/tomo/plugin/bundler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "bundler/helpers"
 require_relative "bundler/tasks"
 

--- a/lib/tomo/plugin/bundler/helpers.rb
+++ b/lib/tomo/plugin/bundler/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo::Plugin::Bundler
   module Helpers
     def bundle(*args, **opts)

--- a/lib/tomo/plugin/bundler/tasks.rb
+++ b/lib/tomo/plugin/bundler/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "yaml"
 
 module Tomo::Plugin::Bundler

--- a/lib/tomo/plugin/core.rb
+++ b/lib/tomo/plugin/core.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "core/helpers"
 require_relative "core/tasks"
 

--- a/lib/tomo/plugin/core/helpers.rb
+++ b/lib/tomo/plugin/core/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "shellwords"
 
 module Tomo::Plugin::Core

--- a/lib/tomo/plugin/core/tasks.rb
+++ b/lib/tomo/plugin/core/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "json"
 require "securerandom"
 

--- a/lib/tomo/plugin/env.rb
+++ b/lib/tomo/plugin/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "env/tasks"
 
 module Tomo::Plugin

--- a/lib/tomo/plugin/env/tasks.rb
+++ b/lib/tomo/plugin/env/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "monitor"
 require "securerandom"
 

--- a/lib/tomo/plugin/git.rb
+++ b/lib/tomo/plugin/git.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "git/helpers"
 require_relative "git/tasks"
 

--- a/lib/tomo/plugin/git/helpers.rb
+++ b/lib/tomo/plugin/git/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo::Plugin::Git
   module Helpers
     def git(*args, **opts)

--- a/lib/tomo/plugin/git/tasks.rb
+++ b/lib/tomo/plugin/git/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "shellwords"
 require "time"
 

--- a/lib/tomo/plugin/nodenv.rb
+++ b/lib/tomo/plugin/nodenv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "nodenv/tasks"
 
 module Tomo::Plugin

--- a/lib/tomo/plugin/nodenv/tasks.rb
+++ b/lib/tomo/plugin/nodenv/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "shellwords"
 
 module Tomo::Plugin::Nodenv

--- a/lib/tomo/plugin/puma.rb
+++ b/lib/tomo/plugin/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "puma/tasks"
 
 module Tomo::Plugin

--- a/lib/tomo/plugin/puma/tasks.rb
+++ b/lib/tomo/plugin/puma/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo::Plugin::Puma
   class Tasks < Tomo::TaskLibrary
     SystemdUnit = Struct.new(:name, :template, :path)

--- a/lib/tomo/plugin/rails.rb
+++ b/lib/tomo/plugin/rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "rails/helpers"
 require_relative "rails/tasks"
 

--- a/lib/tomo/plugin/rails/helpers.rb
+++ b/lib/tomo/plugin/rails/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo::Plugin::Rails
   module Helpers
     def rails(*args, **opts)

--- a/lib/tomo/plugin/rails/tasks.rb
+++ b/lib/tomo/plugin/rails/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo::Plugin::Rails
   class Tasks < Tomo::TaskLibrary
     def assets_precompile

--- a/lib/tomo/plugin/rbenv.rb
+++ b/lib/tomo/plugin/rbenv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "rbenv/tasks"
 
 module Tomo::Plugin

--- a/lib/tomo/plugin/rbenv/tasks.rb
+++ b/lib/tomo/plugin/rbenv/tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "shellwords"
 
 module Tomo::Plugin::Rbenv

--- a/lib/tomo/plugin/testing.rb
+++ b/lib/tomo/plugin/testing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 raise "The testing plugin cannot be used outside of unit tests" unless defined?(Tomo::Testing)
 
 module Tomo::Plugin

--- a/lib/tomo/plugin_dsl.rb
+++ b/lib/tomo/plugin_dsl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module PluginDSL
     def self.extended(mod)

--- a/lib/tomo/remote.rb
+++ b/lib/tomo/remote.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 
 module Tomo

--- a/lib/tomo/result.rb
+++ b/lib/tomo/result.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Result
     def self.empty_success

--- a/lib/tomo/result.rb
+++ b/lib/tomo/result.rb
@@ -3,7 +3,7 @@
 module Tomo
   class Result
     def self.empty_success
-      new(stdout: "", stderr: "", exit_status: 0)
+      new(stdout: +"", stderr: +"", exit_status: 0)
     end
 
     attr_reader :stdout, :stderr, :exit_status

--- a/lib/tomo/runtime.rb
+++ b/lib/tomo/runtime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "time"
 
 module Tomo

--- a/lib/tomo/runtime.rb
+++ b/lib/tomo/runtime.rb
@@ -53,7 +53,7 @@ module Tomo
     end
 
     def run!(task, *args, privileged: false)
-      task = task.dup.extend(PrivilegedTask) if privileged
+      task = String.new(task).extend(PrivilegedTask) if privileged
       execution_plan_for([task], release: :current, args:).execute
     end
 

--- a/lib/tomo/runtime/concurrent_ruby_load_error.rb
+++ b/lib/tomo/runtime/concurrent_ruby_load_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class ConcurrentRubyLoadError < Tomo::Error

--- a/lib/tomo/runtime/concurrent_ruby_thread_pool.rb
+++ b/lib/tomo/runtime/concurrent_ruby_thread_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 concurrent_ver = "~> 1.1"
 
 begin

--- a/lib/tomo/runtime/context.rb
+++ b/lib/tomo/runtime/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class Context

--- a/lib/tomo/runtime/current.rb
+++ b/lib/tomo/runtime/current.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     module Current

--- a/lib/tomo/runtime/execution_plan.rb
+++ b/lib/tomo/runtime/execution_plan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 
 module Tomo

--- a/lib/tomo/runtime/explanation.rb
+++ b/lib/tomo/runtime/explanation.rb
@@ -24,7 +24,7 @@ module Tomo
             indent = threads > 1 ? "  = " : ""
             if threads > 1 && step.applicable_tasks.length > 1
               desc << "#{indent}IN SEQUENCE:"
-              indent.sub!("=", "   ")
+              indent = indent.sub("=", "   ")
             end
             desc << step.explain.gsub(/^/, indent)
           end

--- a/lib/tomo/runtime/explanation.rb
+++ b/lib/tomo/runtime/explanation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class Explanation

--- a/lib/tomo/runtime/host_execution_step.rb
+++ b/lib/tomo/runtime/host_execution_step.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class HostExecutionStep

--- a/lib/tomo/runtime/inline_thread_pool.rb
+++ b/lib/tomo/runtime/inline_thread_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class InlineThreadPool

--- a/lib/tomo/runtime/no_tasks_error.rb
+++ b/lib/tomo/runtime/no_tasks_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class NoTasksError < Error

--- a/lib/tomo/runtime/privileged_task.rb
+++ b/lib/tomo/runtime/privileged_task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     module PrivilegedTask

--- a/lib/tomo/runtime/settings_interpolation.rb
+++ b/lib/tomo/runtime/settings_interpolation.rb
@@ -42,7 +42,7 @@ module Tomo
 
       def dump_settings(hash)
         key_len = hash.keys.map { |k| k.to_s.length }.max
-        dump = "Settings: {\n"
+        dump = +"Settings: {\n"
         hash.to_a.sort_by(&:first).each do |key, value|
           justified_key = "#{key}:".ljust(key_len + 1)
           dump << "  #{justified_key} #{value.inspect},\n"

--- a/lib/tomo/runtime/settings_interpolation.rb
+++ b/lib/tomo/runtime/settings_interpolation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class SettingsInterpolation

--- a/lib/tomo/runtime/settings_required_error.rb
+++ b/lib/tomo/runtime/settings_required_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class SettingsRequiredError < Tomo::Error

--- a/lib/tomo/runtime/settings_required_error.rb
+++ b/lib/tomo/runtime/settings_required_error.rb
@@ -26,7 +26,7 @@ module Tomo
         return "a value for the #{yellow(settings.first.to_s)} setting." if settings.length == 1
 
         sentence = "values for these settings:\n\n  "
-        sentence << settings.map { |s| yellow(s.to_s) }.join("\n  ")
+        sentence + settings.map { |s| yellow(s.to_s) }.join("\n  ")
       end
     end
   end

--- a/lib/tomo/runtime/task_aborted_error.rb
+++ b/lib/tomo/runtime/task_aborted_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class TaskAbortedError < Tomo::Error

--- a/lib/tomo/runtime/task_runner.rb
+++ b/lib/tomo/runtime/task_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class TaskRunner

--- a/lib/tomo/runtime/template_not_found_error.rb
+++ b/lib/tomo/runtime/template_not_found_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class TemplateNotFoundError < Error

--- a/lib/tomo/runtime/unknown_task_error.rb
+++ b/lib/tomo/runtime/unknown_task_error.rb
@@ -12,7 +12,7 @@ module Tomo
         ERROR
 
         sugg = spelling_suggestion || missing_plugin_suggestion
-        error << sugg if sugg
+        error += sugg if sugg
         error
       end
 

--- a/lib/tomo/runtime/unknown_task_error.rb
+++ b/lib/tomo/runtime/unknown_task_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Runtime
     class UnknownTaskError < Error

--- a/lib/tomo/script.rb
+++ b/lib/tomo/script.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class Script
     attr_reader :script

--- a/lib/tomo/shell_builder.rb
+++ b/lib/tomo/shell_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "shellwords"
 
 module Tomo

--- a/lib/tomo/ssh.rb
+++ b/lib/tomo/ssh.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module SSH
     autoload :ChildProcess, "tomo/ssh/child_process"

--- a/lib/tomo/ssh/child_process.rb
+++ b/lib/tomo/ssh/child_process.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "open3"
 require "shellwords"
 require "stringio"

--- a/lib/tomo/ssh/connection.rb
+++ b/lib/tomo/ssh/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fileutils"
 require "securerandom"
 require "tmpdir"

--- a/lib/tomo/ssh/connection_error.rb
+++ b/lib/tomo/ssh/connection_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module SSH
     class ConnectionError < Error

--- a/lib/tomo/ssh/connection_validator.rb
+++ b/lib/tomo/ssh/connection_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "forwardable"
 
 module Tomo

--- a/lib/tomo/ssh/error.rb
+++ b/lib/tomo/ssh/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module SSH
     class Error < Tomo::Error

--- a/lib/tomo/ssh/executable_error.rb
+++ b/lib/tomo/ssh/executable_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module SSH
     class ExecutableError < Error

--- a/lib/tomo/ssh/options.rb
+++ b/lib/tomo/ssh/options.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 module Tomo
   module SSH
     class Options
       DEFAULTS = {
         ssh_connect_timeout: 5,
-        ssh_executable: "ssh".freeze,
+        ssh_executable: "ssh",
         ssh_extra_opts: %w[-o PasswordAuthentication=no].map(&:freeze),
         ssh_forward_agent: true,
         ssh_reuse_connections: true,
-        ssh_strict_host_key_checking: "accept-new".freeze
+        ssh_strict_host_key_checking: "accept-new"
       }.freeze
 
       attr_reader :executable

--- a/lib/tomo/ssh/permission_error.rb
+++ b/lib/tomo/ssh/permission_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module SSH
     class PermissionError < Error

--- a/lib/tomo/ssh/script_error.rb
+++ b/lib/tomo/ssh/script_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "shellwords"
 
 module Tomo

--- a/lib/tomo/ssh/unknown_error.rb
+++ b/lib/tomo/ssh/unknown_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module SSH
     class UnknownError < Error

--- a/lib/tomo/ssh/unsupported_version_error.rb
+++ b/lib/tomo/ssh/unsupported_version_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module SSH
     class UnsupportedVersionError < Error

--- a/lib/tomo/task_api.rb
+++ b/lib/tomo/task_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "erb"
 
 module Tomo

--- a/lib/tomo/task_library.rb
+++ b/lib/tomo/task_library.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   class TaskLibrary
     include TaskAPI

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -1,8 +1,6 @@
-# frozen_string_literal: true
 <% if rubocop? -%>
 # rubocop:disable Style/FormatStringToken
 <% end -%>
-
 plugin "git"
 plugin "env"
 plugin "bundler"
@@ -84,6 +82,5 @@ deploy do
   run "core:log_revision"
 end
 <% if rubocop? -%>
-
 # rubocop:enable Style/FormatStringToken
 <% end -%>

--- a/lib/tomo/templates/config.rb.erb
+++ b/lib/tomo/templates/config.rb.erb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
 <% if rubocop? -%>
 # rubocop:disable Style/FormatStringToken
 <% end -%>
+
 plugin "git"
 plugin "env"
 plugin "bundler"
@@ -82,5 +84,6 @@ deploy do
   run "core:log_revision"
 end
 <% if rubocop? -%>
+
 # rubocop:enable Style/FormatStringToken
 <% end -%>

--- a/lib/tomo/templates/plugin.rb.erb
+++ b/lib/tomo/templates/plugin.rb.erb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 # https://tomo.mattbrictson.com/tutorials/writing-custom-tasks/

--- a/lib/tomo/templates/plugin.rb.erb
+++ b/lib/tomo/templates/plugin.rb.erb
@@ -1,3 +1,1 @@
-# frozen_string_literal: true
-
 # https://tomo.mattbrictson.com/tutorials/writing-custom-tasks/

--- a/lib/tomo/testing.rb
+++ b/lib/tomo/testing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "tomo"
 
 module Tomo

--- a/lib/tomo/testing/cli_extensions.rb
+++ b/lib/tomo/testing/cli_extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Testing
     module CLIExtensions

--- a/lib/tomo/testing/cli_tester.rb
+++ b/lib/tomo/testing/cli_tester.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "securerandom"
 
 module Tomo

--- a/lib/tomo/testing/connection.rb
+++ b/lib/tomo/testing/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Testing
     class Connection < Tomo::SSH::Connection

--- a/lib/tomo/testing/docker_image.rb
+++ b/lib/tomo/testing/docker_image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fileutils"
 require "open3"
 require "securerandom"

--- a/lib/tomo/testing/host_extensions.rb
+++ b/lib/tomo/testing/host_extensions.rb
@@ -16,7 +16,7 @@ module Tomo
       def mock(script, stdout: "", stderr: "", exit_status: 0)
         mocks << [
           script.is_a?(Regexp) ? script : /\A#{Regexp.quote(script)}\z/,
-          Result.new(stdout:, stderr:, exit_status:)
+          Result.new(stdout: String.new(stdout), stderr: String.new(stderr), exit_status:)
         ]
       end
 

--- a/lib/tomo/testing/host_extensions.rb
+++ b/lib/tomo/testing/host_extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Testing
     module HostExtensions

--- a/lib/tomo/testing/local.rb
+++ b/lib/tomo/testing/local.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler"
 require "fileutils"
 require "open3"

--- a/lib/tomo/testing/log_capturing.rb
+++ b/lib/tomo/testing/log_capturing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "stringio"
 
 module Tomo

--- a/lib/tomo/testing/mock_plugin_tester.rb
+++ b/lib/tomo/testing/mock_plugin_tester.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Testing
     class MockPluginTester

--- a/lib/tomo/testing/mocked_exec_error.rb
+++ b/lib/tomo/testing/mocked_exec_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Testing
     class MockedExecError < Exception # rubocop:disable Lint/InheritException

--- a/lib/tomo/testing/mocked_exit_error.rb
+++ b/lib/tomo/testing/mocked_exit_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Testing
     class MockedExitError < Exception # rubocop:disable Lint/InheritException

--- a/lib/tomo/testing/remote_extensions.rb
+++ b/lib/tomo/testing/remote_extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Testing
     module RemoteExtensions

--- a/lib/tomo/testing/ssh_extensions.rb
+++ b/lib/tomo/testing/ssh_extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
   module Testing
     module SSHExtensions

--- a/lib/tomo/testing/systemctl.rb
+++ b/lib/tomo/testing/systemctl.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # THIS SCRIPT IS FOR TESTING PURPOSES ONLY.
 #

--- a/lib/tomo/version.rb
+++ b/lib/tomo/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Tomo
-  VERSION = "1.18.3".freeze
+  VERSION = "1.18.3"
 end

--- a/test/e2e/rails_setup_deploy_e2e_test.rb
+++ b/test/e2e/rails_setup_deploy_e2e_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 require "net/http"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "tomo/testing"
 

--- a/test/tomo/cli/completions_test.rb
+++ b/test/tomo/cli/completions_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Tomo::CLI::CompletionsTest < Minitest::Test

--- a/test/tomo/cli_test.rb
+++ b/test/tomo/cli_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Tomo::CLITest < Minitest::Test

--- a/test/tomo/colors_test.rb
+++ b/test/tomo/colors_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Tomo::ColorsTest < Minitest::Test

--- a/test/tomo/commands/init_test.rb
+++ b/test/tomo/commands/init_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Tomo::Commands::InitTest < Minitest::Test

--- a/test/tomo/console_test.rb
+++ b/test/tomo/console_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "stringio"
 

--- a/test/tomo/host_test.rb
+++ b/test/tomo/host_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Tomo::HostTest < Minitest::Test

--- a/test/tomo/paths_test.rb
+++ b/test/tomo/paths_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Tomo::PathsTest < Minitest::Test

--- a/test/tomo/plugin/bundler/tasks_test.rb
+++ b/test/tomo/plugin/bundler/tasks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "tomo/plugin/bundler"
 

--- a/test/tomo/plugin/core/helpers_test.rb
+++ b/test/tomo/plugin/core/helpers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "tomo/plugin/core"
 

--- a/test/tomo/plugin/core/tasks_test.rb
+++ b/test/tomo/plugin/core/tasks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "tomo/plugin/core"
 require "shellwords"

--- a/test/tomo/plugin/env/tasks_test.rb
+++ b/test/tomo/plugin/env/tasks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "tomo/plugin/env"
 

--- a/test/tomo/plugin/git/tasks_test.rb
+++ b/test/tomo/plugin/git/tasks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "tomo/plugin/git"
 

--- a/test/tomo/plugin/nodenv/tasks_test.rb
+++ b/test/tomo/plugin/nodenv/tasks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "tomo/plugin/nodenv"
 

--- a/test/tomo/plugin/puma/tasks_test.rb
+++ b/test/tomo/plugin/puma/tasks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "tomo/plugin/puma"
 

--- a/test/tomo/plugin/rails/helpers_test.rb
+++ b/test/tomo/plugin/rails/helpers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "tomo/plugin/rails"
 

--- a/test/tomo/plugin/rails/tasks_test.rb
+++ b/test/tomo/plugin/rails/tasks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "tomo/plugin/rails"
 

--- a/test/tomo/plugin/rbenv/tasks_test.rb
+++ b/test/tomo/plugin/rbenv/tasks_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "tomo/plugin/rbenv"
 

--- a/test/tomo/runtime/execution_plan_test.rb
+++ b/test/tomo/runtime/execution_plan_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Tomo::Runtime::ExecutionPlanTest < Minitest::Test

--- a/test/tomo/runtime/execution_plan_test.rb
+++ b/test/tomo/runtime/execution_plan_test.rb
@@ -89,7 +89,7 @@ class Tomo::Runtime::ExecutionPlanTest < Minitest::Test
     config = single_host_config
     runtime = config.build_runtime
     plan = runtime.execution_plan_for(
-      setup_tasks + ["puma:setup_systemd".extend(Tomo::Runtime::PrivilegedTask)]
+      setup_tasks + [(+"puma:setup_systemd").extend(Tomo::Runtime::PrivilegedTask)]
     )
     assert_equal(<<~PLAN.strip, plan.explain)
       CONCURRENTLY (2 THREADS):
@@ -106,7 +106,7 @@ class Tomo::Runtime::ExecutionPlanTest < Minitest::Test
     config = role_based_multi_host_config
     runtime = config.build_runtime
     plan = runtime.execution_plan_for(
-      setup_tasks + ["puma:setup_systemd".extend(Tomo::Runtime::PrivilegedTask)]
+      setup_tasks + [(+"puma:setup_systemd").extend(Tomo::Runtime::PrivilegedTask)]
     )
     assert_equal(<<~PLAN.strip, plan.explain)
       CONCURRENTLY (3 THREADS):

--- a/test/tomo/runtime/settings_interpolation_test.rb
+++ b/test/tomo/runtime/settings_interpolation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Tomo::Runtime::SettingsInterpolationTest < Minitest::Test

--- a/test/tomo/runtime_test.rb
+++ b/test/tomo/runtime_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Tomo::RuntimeTest < Minitest::Test

--- a/test/tomo/shell_builder_test.rb
+++ b/test/tomo/shell_builder_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Tomo::ShellBuilderTest < Minitest::Test
@@ -7,7 +9,7 @@ class Tomo::ShellBuilderTest < Minitest::Test
   end
 
   def test_raw_works_with_frozen_strings
-    raw_string = Tomo::ShellBuilder.raw("$HOME".freeze)
+    raw_string = Tomo::ShellBuilder.raw("$HOME")
     assert_equal("$HOME", raw_string.shellescape)
   end
 end

--- a/test/tomo/task_api_test.rb
+++ b/test/tomo/task_api_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Tomo::TaskAPITest < Minitest::Test

--- a/tomo.gemspec
+++ b/tomo.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/tomo/version"
 
 Gem::Specification.new do |spec|


### PR DESCRIPTION
This PR adds the `# frozen_string_literal: true` comment to all of tomo's Ruby files.

This prepares tomo for a future version of Ruby (4?), where string literals will likely become frozen by default.