### PR TITLE
Fix `TypeError` when `tomo/config.rb` uses frozen string literals

### DIFF
--- a/lib/tomo/configuration/dsl/batch_block.rb
+++ b/lib/tomo/configuration/dsl/batch_block.rb
@@ -7,7 +7,7 @@ module Tomo
         end
 
         def run(task, privileged: false)
-          task.extend(Runtime::PrivilegedTask) if privileged
+          task = String.new(task).extend(Runtime::PrivilegedTask) if privileged
           @batch << task
           self
         end

--- a/lib/tomo/configuration/dsl/tasks_block.rb
+++ b/lib/tomo/configuration/dsl/tasks_block.rb
@@ -14,7 +14,7 @@ module Tomo
         end
 
         def run(task, privileged: false)
-          task.extend(Runtime::PrivilegedTask) if privileged
+          task = String.new(task).extend(Runtime::PrivilegedTask) if privileged
           @tasks << task
           self
         end

--- a/lib/tomo/host.rb
+++ b/lib/tomo/host.rb
@@ -31,7 +31,7 @@ module Tomo
 
     def to_s
       str = user ? "#{user}@#{address}" : address
-      str << ":#{port}" unless port == 22
+      str += ":#{port}" unless port == 22
       str
     end
 

--- a/lib/tomo/runtime.rb
+++ b/lib/tomo/runtime.rb
@@ -51,7 +51,7 @@ module Tomo
     end
 
     def run!(task, *args, privileged: false)
-      task = task.dup.extend(PrivilegedTask) if privileged
+      task = String.new(task).extend(PrivilegedTask) if privileged
       execution_plan_for([task], release: :current, args:).execute
     end
 

--- a/test/tomo/configuration_test.rb
+++ b/test/tomo/configuration_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class Tomo::ConfigurationTest < Minitest::Test
+  include Tomo::Testing::Local
+
+  def test_parses_a_config_file_that_contains_frozen_string_literals
+    in_temp_dir do
+      FileUtils.mkdir ".tomo"
+      File.write(".tomo/config.rb", <<~CONFIG)
+        # frozen_string_literal: true
+
+        setup do
+          run "nginx:setup", privileged: true
+        end
+      CONFIG
+
+      parsed = Tomo::Configuration.from_config_rb
+
+      assert_instance_of(Tomo::Configuration, parsed)
+    end
+  end
+end


### PR DESCRIPTION
If the `.tomo/config.rb` file declares a setup or deploy task with `privileged: true` and the file starts with the special `# frozen_string_literal: true` comment, tomo crashes with the following error message:

```
TypeError: can't define singleton
    lib/tomo/configuration/dsl/tasks_block.rb:17:in `extend_object'
    lib/tomo/configuration/dsl/tasks_block.rb:17:in `extend'
    lib/tomo/configuration/dsl/tasks_block.rb:17:in `run'
```

This is because tomo is trying to call `.extend` on a frozen string.

Fix by creating a mutable copy of task names before extending them.