### PR TITLE
Fix `FrozenError` when using interactive environment selector

### DIFF
--- a/lib/tomo/console/key_reader.rb
+++ b/lib/tomo/console/key_reader.rb
@@ -10,7 +10,7 @@ module Tomo
       extend Forwardable
 
       def initialize(input=$stdin)
-        @buffer = ""
+        @buffer = +""
         @input = input
       end
 

--- a/test/tomo/console/key_reader_test.rb
+++ b/test/tomo/console/key_reader_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "stringio"
+
+class Tomo::Console
+  class KeyReaderTest < Minitest::Test
+    def setup
+      @input = StringIO.new
+      @input.define_singleton_method(:raw) do |&block|
+        block.call
+      end
+    end
+
+    def test_reads_a_single_keystroke
+      @input << "h"
+      @input.rewind
+
+      key_reader = KeyReader.new(@input)
+      char = key_reader.next
+
+      assert_equal("h", char)
+    end
+  end
+end


### PR DESCRIPTION
When running `tomo deploy` in a multi-environment project with no environment explicitly specified, tomo prompts:

```
Choose an environment: 
❯ staging
  production
```

Interacting with this menu with the keyboard would result in an error:

```
forwardable.rb:240:in 'String#clear': can't modify frozen String: "" (FrozenError)
	from forwardable.rb:240:in 'Tomo::Console::KeyReader#clear'
```

This is because the internal `buffer` used by `KeyReader` was frozen as a side effect of #446.

Fix by marking `buffer` as mutable.