### PR TITLE
Fix TypeError on Ruby head in Tomo::Path

### DIFF
--- a/lib/tomo/path.rb
+++ b/lib/tomo/path.rb
@@ -11,11 +11,11 @@ module Tomo
     end
 
     def join(*other)
-      self.class.new(Pathname.new(self).join(*other))
+      self.class.new(Pathname.new(to_s).join(*other))
     end
 
     def dirname
-      self.class.new(Pathname.new(self).dirname)
+      self.class.new(Pathname.new(to_s).dirname)
     end
   end
 end

--- a/test/tomo/path_test.rb
+++ b/test/tomo/path_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Tomo::PathTest < Minitest::Test
+  def test_join
+    path = Tomo::Path.new("/some/path").join("tmp/file.txt")
+
+    assert_kind_of(Tomo::Path, path)
+    assert_equal("/some/path/tmp/file.txt", path.to_s)
+  end
+
+  def test_dirname
+    path = Tomo::Path.new("/root/tmp/file.txt").dirname
+
+    assert_kind_of(Tomo::Path, path)
+    assert_equal("/root/tmp", path.to_s)
+  end
+end


### PR DESCRIPTION
Fixes the following error when tomo is used on Ruby head:

```
TypeError: TypeError
    vendor/bundle/ruby/3.5.0+3/gems/tomo-1.21.0/lib/tomo/path.rb:18:in 'Pathname#initialize'
    vendor/bundle/ruby/3.5.0+3/gems/tomo-1.21.0/lib/tomo/path.rb:18:in 'Tomo::Path#dirname'
```