### PR TITLE
Add `--quiet` option to silence progress output

### DIFF
--- a/docs/api/Logger.md
+++ b/docs/api/Logger.md
@@ -28,6 +28,8 @@ tomo run v1.0.0
 * Simulated bundler:clean on deployer@web1.example.com and deployer@web2.example.com (dry run)
 ```
 
+If tomo is run with the `--quiet` option, all log messages are silenced, except `warn` and `error`.
+
 ## Instance methods
 
 ### debug(message) → nil

--- a/docs/api/TaskLibrary.md
+++ b/docs/api/TaskLibrary.md
@@ -126,6 +126,10 @@ logger.info "hi!"
 logger.warn "uh oh"
 ```
 
+### quiet? → true or false
+
+Returns `true` if tomo was started with the `--quiet` option.
+
 ### die(reason)
 
 Immediately halt task execution by raising an exception. This will automatically print information to stderr about what task failed, on which host, and the `reason` for the failure.

--- a/docs/include/common_options.md.include
+++ b/docs/include/common_options.md.include
@@ -1,4 +1,5 @@
 | `--[no-]color` | By default, tomo automatically determines whether to use color output based on the capabilities of the terminal. Use this option to override this behavior and force tomo to enable or disable color output. |
 | `--[no-]debug` | Enables verbose logging output that is helpful for troubleshooting. This includes runtime information such as the environment variables on the remote host and all tomo settings. Each SSH command executed by tomo is also logged in detail. |
+| `--[no-]quiet` | Silences all progress output, such as "connecting to <host>" and the names of tasks as they are executed. |
 | `--[no-]trace` | Normally if a tomo command fails, a concise and helpful error message is printed. If `--trace` is specified, tomo will also print the full backtrace. |
 | `-h`, `--help` | Prints the help for this tomo command, similar to what you see on this page. |

--- a/lib/tomo.rb
+++ b/lib/tomo.rb
@@ -27,7 +27,7 @@ module Tomo
 
   class << self
     attr_accessor :logger
-    attr_writer :debug, :dry_run
+    attr_writer :debug, :dry_run, :quiet
 
     def debug?
       !!@debug
@@ -37,6 +37,10 @@ module Tomo
       !!@dry_run
     end
 
+    def quiet?
+      !!@quiet
+    end
+
     def bundled?
       !!(defined?(Bundler) && ENV["BUNDLE_GEMFILE"])
     end
@@ -44,5 +48,6 @@ module Tomo
 
   self.debug = false
   self.dry_run = false
+  self.quiet = false
   self.logger = Logger.new
 end

--- a/lib/tomo/cli/common_options.rb
+++ b/lib/tomo/cli/common_options.rb
@@ -11,6 +11,9 @@ module Tomo
           option :debug, "--[no-]debug", "Enable/disable verbose debug logging" do |debug|
             Tomo.debug = debug
           end
+          option :quiet, "--[no-]quiet", "Silence all progress output" do |quiet|
+            Tomo.quiet = quiet
+          end
           option :trace, "--[no-]trace", "Display full backtrace on error" do |trace|
             CLI.show_backtrace = trace
           end

--- a/lib/tomo/logger.rb
+++ b/lib/tomo/logger.rb
@@ -15,6 +15,7 @@ module Tomo
     end
 
     def script_start(script)
+      return if Tomo.quiet?
       return unless script.echo?
 
       puts yellow(script.echo_string)
@@ -27,6 +28,7 @@ module Tomo
     end
 
     def script_end(script, result)
+      return if Tomo.quiet?
       return unless result.failure?
       return unless script.silent?
       return unless script.raise_on_error?
@@ -35,14 +37,20 @@ module Tomo
     end
 
     def connect(host)
+      return if Tomo.quiet?
+
       puts gray("→ Connecting to #{host}")
     end
 
     def task_start(task)
+      return if Tomo.quiet?
+
       puts blue("• #{task}")
     end
 
     def info(message)
+      return if Tomo.quiet?
+
       puts message
     end
 

--- a/lib/tomo/task_api.rb
+++ b/lib/tomo/task_api.rb
@@ -18,6 +18,10 @@ module Tomo
       Tomo.dry_run?
     end
 
+    def quiet?
+      Tomo.quiet?
+    end
+
     def logger
       Tomo.logger
     end

--- a/lib/tomo/testing/cli_tester.rb
+++ b/lib/tomo/testing/cli_tester.rb
@@ -37,6 +37,7 @@ module Tomo
       ensure
         Tomo.debug = false
         Tomo.dry_run = false
+        Tomo.quiet = false
         Tomo::CLI.show_backtrace = false
         Tomo::CLI::Completions.instance_variable_set(:@active, false)
       end

--- a/test/tomo/cli_test.rb
+++ b/test/tomo/cli_test.rb
@@ -7,6 +7,12 @@ class Tomo::CLITest < Minitest::Test
     @tester = Tomo::Testing::CLITester.new
   end
 
+  def test_quiet_option_silences_stdout
+    @tester.run "init"
+    @tester.run "run", "bundler:install", "--dry-run", "--quiet"
+    assert_empty @tester.stdout
+  end
+
   def test_execute_task_with_implicit_run_command
     @tester.run "init"
     @tester.run "bundler:install", "--dry-run"

--- a/test/tomo/logger_test.rb
+++ b/test/tomo/logger_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Tomo::LoggerTest < Minitest::Test
+  def setup
+    @stdout_io = StringIO.new
+    @stderr_io = StringIO.new
+    @logger = Tomo::Logger.new(stdout: @stdout_io, stderr: @stderr_io)
+  end
+
+  def teardown
+    # Restore defaults
+    Tomo.debug = false
+    Tomo.quiet = false
+  end
+
+  def test_quiet_mode_silences_info
+    Tomo.quiet = true
+    @logger.info("testing")
+
+    assert_empty(stdout)
+    assert_empty(stderr)
+  end
+
+  def test_quiet_mode_doesnt_silence_error
+    Tomo.quiet = true
+    @logger.error("testing")
+
+    assert_equal("  \n  ERROR: testing\n  \n", stderr)
+  end
+
+  def test_quiet_mode_doesnt_silence_warn
+    Tomo.quiet = true
+    @logger.warn("testing")
+
+    assert_equal("WARNING: testing\n", stderr)
+  end
+
+  def test_quiet_mode_doesnt_silence_debug
+    Tomo.debug = true
+    Tomo.quiet = true
+    @logger.debug("testing")
+
+    assert_equal("DEBUG: testing\n", stderr)
+  end
+
+  private
+
+  def stdout
+    @stdout_io.string
+  end
+
+  def stderr
+    @stderr_io.string
+  end
+end


### PR DESCRIPTION
If tomo is run with the `--quiet` option, all log messages are silenced, except `warn` and `error`.