### PR TITLE
Add `rails:query` task (requires Rails 8.2)

### DIFF
--- a/docs/api/Logger.md
+++ b/docs/api/Logger.md
@@ -28,7 +28,12 @@ tomo run v1.0.0
 * Simulated bundler:clean on deployer@web1.example.com and deployer@web2.example.com (dry run)
 ```
 
-If tomo is run with the `--quiet` option, all log messages are silenced, except `warn` and `error`.
+If tomo is run with the `--quiet` option, all progress messages and info messages are silenced. Script output, warnings, and errors are still printed.
+
+```
+$ tomo run bundler:install --quiet
+The Gemfile's dependencies are satisfied
+```
 
 ## Instance methods
 

--- a/docs/plugins/rails.md
+++ b/docs/plugins/rails.md
@@ -78,6 +78,28 @@ Runs `bundle exec rake db:schema:load` to load the schema from `db/schema.rb` in
 
 Runs `bundle exec rake db:structure:load` to load the schema from `db/structure.sql` into an existing database. This task is intended for use as a [setup](../commands/setup.md) task after `rails:db_create`. It will be automatically skipped if the database already contains a schema, so it is safe to re-run.
 
+### rails:query
+
+Executes read-only database queries using `bundle exec rails query [ARGS]`, printing the results as structured data in JSON format. Use tomo’s `--quiet` option to silence progress output, ensuring only JSON is printed. The `--` separator can be used to delineate tomo options from `query` options. Example:
+
+```
+$ bin/tomo run --quiet rails:query -- --sql "SELECT id, name FROM accounts LIMIT 2"
+{
+  "columns": ["id", "name"],
+  "rows": [[1, "Acme"], [2, "Widgets Co"]],
+  "meta": {
+    "row_count": 2,
+    "query_time_ms": 1.8,
+    "page": 1,
+    "per_page": 100,
+    "has_more": false,
+    "sql": "SELECT id, name FROM accounts LIMIT 2"
+  }
+}
+```
+
+See the [Rails Guides](https://edgeguides.rubyonrails.org/command_line.html#bin-rails-query) to learn more about `rails query`.
+
 ## Helpers
 
 These helper methods become available on instances of [Remote](../api/Remote.md) when the rails plugin is loaded. They accept the same `options` as [Remote#run](../api/Remote.md#run42command-4242options-tomoresult).

--- a/lib/tomo/plugin/rails/tasks.rb
+++ b/lib/tomo/plugin/rails/tasks.rb
@@ -10,6 +10,10 @@ module Tomo::Plugin::Rails
       remote.rails("console", settings[:run_args], attach: true)
     end
 
+    def query
+      remote.rails("query", settings[:run_args], attach: true)
+    end
+
     def db_console
       remote.rails("dbconsole", "--include-password", settings[:run_args], attach: true)
     end

--- a/test/tomo/plugin/rails/tasks_test.rb
+++ b/test/tomo/plugin/rails/tasks_test.rb
@@ -11,4 +11,12 @@ class Tomo::Plugin::Rails::TasksTest < Minitest::Test
     assert_raises(Tomo::Testing::MockedExecError) { tester.run_task("rails:db_console") }
     assert_equal("cd /app/current && bundle exec rails dbconsole --include-password", tester.executed_script)
   end
+
+  def test_query
+    tester = Tomo::Testing::MockPluginTester.new(
+      "bundler", "rails", settings: { current_path: "/app/current" }
+    )
+    assert_raises(Tomo::Testing::MockedExecError) { tester.run_task("rails:query", "schema") }
+    assert_equal("cd /app/current && bundle exec rails query schema", tester.executed_script)
+  end
 end


### PR DESCRIPTION
Executes read-only database queries using `bundle exec rails query [ARGS]`, printing the results as structured data in JSON format. Use tomo’s `--quiet` option to silence progress output, ensuring only JSON is printed. The `--` separator can be used to delineate tomo options from `query` options. Example:

```
$ bin/tomo run --quiet rails:query -- --sql "SELECT id, name FROM accounts LIMIT 2"
{
  "columns": ["id", "name"],
  "rows": [[1, "Acme"], [2, "Widgets Co"]],
  "meta": {
    "row_count": 2,
    "query_time_ms": 1.8,
    "page": 1,
    "per_page": 100,
    "has_more": false,
    "sql": "SELECT id, name FROM accounts LIMIT 2"
  }
}
```

Uses the new `bin/rails query` CLI command in Rails 8.2: https://edgeguides.rubyonrails.org/command_line.html#bin-rails-query