### PR TITLE
Allow settings interpolation withing `:env_vars` values

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,6 +127,15 @@ set bundler_path: "%{shared_path}/bundle"
 # => "/var/www/my-app/shared/bundle"
 ```
 
+References within hash values are also interpolated. This is useful for setting `:env_vars`:
+
+```ruby
+set env_vars: {
+  DATABASE_URL: "sqlite:%{shared_path}/production.db"
+}
+# => { DATABASE_URL: "/var/www/my-app/shared/production.db" }
+```
+
 Interpolation takes place after tomo has loaded all configuration, plugins, and overrides, just before tasks are run.
 
 #### Custom settings

--- a/lib/tomo/runtime/settings_interpolation.rb
+++ b/lib/tomo/runtime/settings_interpolation.rb
@@ -23,11 +23,22 @@ module Tomo
 
       def fetch(name, stack=[])
         raise_circular_dependency_error(name, stack) if stack.include?(name)
-        value = settings.fetch(name)
-        return value unless value.is_a?(String)
 
+        stack += [name]
+        value = settings.fetch(name)
+
+        if value.is_a?(String)
+          interpolate_string(value, stack)
+        elsif value.is_a?(Hash)
+          value.transform_values { |v| v.is_a?(String) ? interpolate_string(v, stack) : v }
+        else
+          value
+        end
+      end
+
+      def interpolate_string(value, stack)
         value.gsub(/%{(\w+)}/) do
-          fetch(Regexp.last_match[1].to_sym, stack + [name])
+          fetch(Regexp.last_match[1].to_sym, stack)
         end
       end
 

--- a/test/tomo/runtime/settings_interpolation_test.rb
+++ b/test/tomo/runtime/settings_interpolation_test.rb
@@ -8,14 +8,22 @@ class Tomo::Runtime::SettingsInterpolationTest < Minitest::Test
       application: "test",
       deploy_to: "/var/www/%{application}",
       current_path: "%{deploy_to}/current",
-      application_json_path: "%{deploy_to}/%{application}.json"
+      application_json_path: "%{deploy_to}/%{application}.json",
+      env_vars: {
+        DATABASE_URL: "sqlite:%{deploy_to}/sqlite.db",
+        SECRET_KEY_BASE: :generate_secret
+      }
     )
     assert_equal(
       {
         application: "test",
         deploy_to: "/var/www/test",
         current_path: "/var/www/test/current",
-        application_json_path: "/var/www/test/test.json"
+        application_json_path: "/var/www/test/test.json",
+        env_vars: {
+          DATABASE_URL: "sqlite:/var/www/test/sqlite.db",
+          SECRET_KEY_BASE: :generate_secret
+        }
       },
       interpolated
     )


### PR DESCRIPTION
References within hash values are now interpolated. This is useful for setting `:env_vars`:

```ruby
set env_vars: {
  DATABASE_URL: "sqlite:%{shared_path}/production.db"
}
# => { DATABASE_URL: "/var/www/my-app/shared/production.db" }
```
