### PR TITLE
Fix unintended verbose output when running `rake -m`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-require "rake/testtask"
+require "minitest/test_task"
 require "rubocop/rake_task"
 
 task default: %i[test rubocop]
@@ -10,16 +10,12 @@ task test: %w[test:unit]
 
 RuboCop::RakeTask.new
 
-Rake::TestTask.new("test:unit") do |t|
-  t.libs << "test"
-  t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"] - FileList["test/**/*_e2e_test.rb"]
+Minitest::TestTask.create("test:unit") do |t|
+  t.test_globs = FileList["test/**/*_test.rb"] - FileList["test/**/*_e2e_test.rb"]
 end
 
-Rake::TestTask.new("test:e2e") do |t|
-  t.libs << "test"
-  t.libs << "lib"
-  t.test_files = FileList["test/**/*_e2e_test.rb"]
+Minitest::TestTask.create("test:e2e") do |t|
+  t.test_globs = FileList["test/**/*_e2e_test.rb"]
 end
 
 # == "rake release" enhancements ==============================================


### PR DESCRIPTION
# Problem

Running `rake -m` would for some reason switch Minitest into verbose mode, showing the full name of each test, like this:

```
# Running:

Tomo::PathTest#test_join = 0.00 s = .
Tomo::PathTest#test_dirname = 0.00 s = .
Tomo::Plugin::Env::TasksTest#test_does_not_overwrite_previously_generated_secret = 0.00 s = .
Tomo::Plugin::Env::TasksTest#test_setup_fails_if_wrong_envrc_already_exists_in_bashrc = 0.00 s = .
Tomo::Plugin::Env::TasksTest#test_setup_does_not_modify_bashrc_if_it_is_already_set_up = 0.00 s = .
Tomo::Plugin::Env::TasksTest#test_setup_generates_a_random_value_for_var_marked_as_generate_secret = 0.00 s = .
Tomo::Plugin::Env::TasksTest#test_executes_chmod_to_reduce_visibility_of_envrc_file_upon_creation = 0.00 s = .
Tomo::Plugin::Env::TasksTest#test_setup_allows_integer_value = 0.00 s = .
```

# Solution

Use `Minitest::TestTask` instead of `Rake::TestTask`. This shows the intended output when using `rake -m`.

```
# Running:

.............................................
```